### PR TITLE
Add inline markdown rendering support via AttributedString

### DIFF
--- a/AEPConcierge.xcodeproj/project.pbxproj
+++ b/AEPConcierge.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		4C3A65D32E55272400EEEF3B /* ChatComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3A65BF2E55272300EEEF3B /* ChatComposer.swift */; };
 		4C3A65D52E55446600EEEF3B /* UIKitDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3A65D42E55446600EEEF3B /* UIKitDemoViewController.swift */; };
 		4C3A65D72E55600F00EEEF3B /* InputReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3A65D62E55600F00EEEF3B /* InputReducer.swift */; };
+		4C3A65DD2E5E65C300EEEF3B /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3A65DC2E5E65C300EEEF3B /* MarkdownRenderer.swift */; };
 		4C952FFB2E4BE8FD00772695 /* S2_Icon_AudioWave_20_N.svg in Resources */ = {isa = PBXBuildFile; fileRef = 4C952E4D2E4BE8FD00772695 /* S2_Icon_AudioWave_20_N.svg */; };
 		4C95303E2E4BE8FD00772695 /* S2_Icon_ClockPending_20_N.svg in Resources */ = {isa = PBXBuildFile; fileRef = 4C952E782E4BE8FD00772695 /* S2_Icon_ClockPending_20_N.svg */; };
 		4C9530742E4BE8FD00772695 /* S2_Icon_Close_20_N.svg in Resources */ = {isa = PBXBuildFile; fileRef = 4C952E792E4BE8FD00772695 /* S2_Icon_Close_20_N.svg */; };
@@ -193,6 +194,7 @@
 		4C3A65CA2E55272300EEEF3B /* BrandIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandIcon.swift; sourceTree = "<group>"; };
 		4C3A65D42E55446600EEEF3B /* UIKitDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitDemoViewController.swift; sourceTree = "<group>"; };
 		4C3A65D62E55600F00EEEF3B /* InputReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputReducer.swift; sourceTree = "<group>"; };
+		4C3A65DC2E5E65C300EEEF3B /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
 		4C952E4D2E4BE8FD00772695 /* S2_Icon_AudioWave_20_N.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = S2_Icon_AudioWave_20_N.svg; sourceTree = "<group>"; };
 		4C952E782E4BE8FD00772695 /* S2_Icon_ClockPending_20_N.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = S2_Icon_ClockPending_20_N.svg; sourceTree = "<group>"; };
 		4C952E792E4BE8FD00772695 /* S2_Icon_Close_20_N.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = S2_Icon_Close_20_N.svg; sourceTree = "<group>"; };
@@ -338,6 +340,7 @@
 			isa = PBXGroup;
 			children = (
 				249899822D67C5F90005CBD7 /* Color+Extensions.swift */,
+				4C3A65DC2E5E65C300EEEF3B /* MarkdownRenderer.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -694,9 +697,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ConciergeDemoApp/Pods-ConciergeDemoApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ConciergeDemoApp/Pods-ConciergeDemoApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -733,9 +740,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-UnitTests/Pods-UnitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-UnitTests/Pods-UnitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -824,6 +835,7 @@
 				2482FDE02E3BED830032F3CA /* SpeechCapturer.swift in Sources */,
 				24317CB72E5CC5CC00F138E9 /* SchemaObject.swift in Sources */,
 				2482FDDD2E3BEA210032F3CA /* SpeechCapturing.swift in Sources */,
+				4C3A65DD2E5E65C300EEEF3B /* MarkdownRenderer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AEPConcierge/Sources/Extensions/MarkdownRenderer.swift
+++ b/AEPConcierge/Sources/Extensions/MarkdownRenderer.swift
@@ -1,0 +1,93 @@
+/*
+ Copyright 2025 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import SwiftUI
+
+/// Renders markdown into an AttributedString, leveraging the system markdown parser
+/// and applying text style changes where applicable.
+enum MarkdownRenderer {
+    /// Parse and style a markdown string into an AttributedString.
+    /// - Parameter markdown: The markdown source text.
+    /// - Returns: A styled AttributedString for use with SwiftUI `Text(_:)` or UIKit.
+    static func render(_ markdown: String) -> AttributedString {
+        // Parse using system markdown support
+        let options = AttributedString.MarkdownParsingOptions(
+            // Preserve literal newlines and whitespace, but parse inline markdown like **bold**, _italic_, `code`, and links
+            interpretedSyntax: .inlineOnlyPreservingWhitespace,
+            failurePolicy: .returnPartiallyParsedIfPossible
+        )
+
+        guard var attributed = try? AttributedString(markdown: markdown, options: options) else {
+            return AttributedString(markdown)
+        }
+
+        applyInlineStyles(&attributed)
+        applyBlockStyles(&attributed)
+        return attributed
+    }
+
+    // MARK: - Styling
+    private static func applyInlineStyles(_ attributed: inout AttributedString) {
+        var container = AttributeContainer()
+        let swiftUIFontScope = AttributeScopes.SwiftUIAttributes.self
+
+        for run in attributed.runs {
+            // For inline code styling, apply monospaced font
+            if let intent = run.inlinePresentationIntent, intent.contains(.code) {
+                container[swiftUIFontScope.FontAttribute.self] = .system(.body, design: .monospaced)
+                attributed[run.range].mergeAttributes(container)
+                container = AttributeContainer()
+            }
+        }
+    }
+
+    private static func applyBlockStyles(_ attributed: inout AttributedString) {
+        let swiftUIFontScope = AttributeScopes.SwiftUIAttributes.self
+        let uiKitScope = AttributeScopes.UIKitAttributes.self
+
+        for run in attributed.runs {
+            if let presentation = run.presentationIntent {
+                for component in presentation.components {
+                    switch component.kind {
+                    case .header(let level):
+                        var container = AttributeContainer()
+                        // Map heading levels to font sizes/weights
+                        let font: Font
+                        switch level {
+                        case 1: font = .system(size: 22, weight: .bold)
+                        case 2: font = .system(size: 20, weight: .semibold)
+                        case 3: font = .system(size: 18, weight: .semibold)
+                        default: font = .system(size: 16, weight: .semibold)
+                        }
+                        container[swiftUIFontScope.FontAttribute.self] = font
+                        attributed[run.range].mergeAttributes(container)
+
+                    case .blockQuote:
+                        var container = AttributeContainer()
+                        // Slightly dim quotes to differentiate
+                        container[uiKitScope.ForegroundColorAttribute.self] = UIColor.secondaryLabel
+                        attributed[run.range].mergeAttributes(container)
+                    default:
+                        break
+                    }
+                }
+            }
+        }
+    }
+}
+
+extension Text {
+    /// Convenience helper to create a Text view from markdown using MarkdownRenderer.
+    static func markdown(_ markdown: String) -> Text {
+        return Text(MarkdownRenderer.render(markdown))
+    }
+}

--- a/AEPConcierge/Sources/Views/ChatMessageView.swift
+++ b/AEPConcierge/Sources/Views/ChatMessageView.swift
@@ -35,7 +35,8 @@ struct ChatMessageView: View {
             HStack(alignment: .bottom) {
                 if isUserMessage { Spacer() }
 
-                Text(messageBody ?? "")
+                // Render agent messages with inline markdown
+                (isUserMessage ? Text(messageBody ?? "") : Text.markdown(messageBody ?? ""))
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)
                     .textSelection(.enabled)
@@ -45,6 +46,15 @@ struct ChatMessageView: View {
                             .fill(isUserMessage ? theme.primary : theme.agentBubble)
                     )
                     .compositingGroup()
+                    .contextMenu {
+                        Button(action: {
+                            let source = messageBody ?? ""
+                            // Copy raw markdown (preserve markers)
+                            UIPasteboard.general.string = source
+                        }) {
+                            Label("Copy", systemImage: "doc.on.doc")
+                        }
+                    }
 
                 if !isUserMessage { Spacer() }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds inline markdown rendering support via AttributedString's built in:
```swift
let options = AttributedString.MarkdownParsingOptions(
            // Preserve literal newlines and whitespace, but parse inline markdown like **bold**, _italic_, `code`, and links
            interpretedSyntax: .inlineOnlyPreservingWhitespace,
            failurePolicy: .returnPartiallyParsedIfPossible
        )
```

This means only inline styling like bold, italic, links, strikethrough, and code styling (inline and block) work. All other markdown styling like tables, headers, paragraphs, block quotes, lists, etc will not work

<img height="700" alt="Screenshot 2025-08-26 at 4 39 10 PM" src="https://github.com/user-attachments/assets/b14b14b8-5e75-4aea-9745-3e184a1afefe" />

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
