### PR TITLE
Add prompt suggestions theming support

### DIFF
--- a/AEPBrandConcierge/Sources/Theme/Models/ConciergeTheme.swift
+++ b/AEPBrandConcierge/Sources/Theme/Models/ConciergeTheme.swift
@@ -222,6 +222,8 @@ private extension ConciergeTheme {
         resolved.chatMessage.userBackground = colors.message.userBackground
         resolved.chatMessage.userText = colors.message.userText
         resolved.chatMessage.conciergeBackground = colors.message.conciergeBackground
+            ?? colors.primary.container
+            ?? CodableColor(Color(UIColor.systemBackground))
         resolved.chatMessage.conciergeText = colors.message.conciergeText
         resolved.chatMessage.linkColor = colors.message.conciergeLink
         resolved.chatMessage.borderRadius = layout.messageBorderRadius

--- a/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeBehavior.swift
+++ b/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeBehavior.swift
@@ -237,6 +237,12 @@ public struct ConciergePromptSuggestionsBehavior: Codable {
     /// Align chips to the inner content edge of the bot message bubble. Default: `false`.
     public var alignToMessage: Bool
 
+    private enum CodingKeys: String, CodingKey {
+        case itemMaxLines
+        case showHeader
+        case alignToMessage
+    }
+
     public init(
         itemMaxLines: Int = 1,
         showHeader: Bool = false,
@@ -252,6 +258,13 @@ public struct ConciergePromptSuggestionsBehavior: Codable {
         itemMaxLines = try container.decodeIfPresent(Int.self, forKey: .itemMaxLines) ?? 1
         showHeader = try container.decodeIfPresent(Bool.self, forKey: .showHeader) ?? false
         alignToMessage = try container.decodeIfPresent(Bool.self, forKey: .alignToMessage) ?? false
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(itemMaxLines, forKey: .itemMaxLines)
+        try container.encode(showHeader, forKey: .showHeader)
+        try container.encode(alignToMessage, forKey: .alignToMessage)
     }
 }
 

--- a/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeBehavior.swift
+++ b/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeBehavior.swift
@@ -228,6 +228,33 @@ public struct ConciergeProductCardBehavior: Codable {
     }
 }
 
+/// Prompt suggestions behavior configuration
+public struct ConciergePromptSuggestionsBehavior: Codable {
+    /// Max lines of text per chip before ellipsis. Default: `1`.
+    public var itemMaxLines: Int
+    /// Show a customizable "Suggestions" header label above the chips. Default: `false`.
+    public var showHeader: Bool
+    /// Align chips to the inner content edge of the bot message bubble. Default: `false`.
+    public var alignToMessage: Bool
+
+    public init(
+        itemMaxLines: Int = 1,
+        showHeader: Bool = false,
+        alignToMessage: Bool = false
+    ) {
+        self.itemMaxLines = itemMaxLines
+        self.showHeader = showHeader
+        self.alignToMessage = alignToMessage
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        itemMaxLines = try container.decodeIfPresent(Int.self, forKey: .itemMaxLines) ?? 1
+        showHeader = try container.decodeIfPresent(Bool.self, forKey: .showHeader) ?? false
+        alignToMessage = try container.decodeIfPresent(Bool.self, forKey: .alignToMessage) ?? false
+    }
+}
+
 /// Privacy notice configuration
 public struct ConciergePrivacyNoticeBehavior: Codable {
     public var title: String
@@ -252,6 +279,7 @@ public struct ConciergeBehaviorConfig: Codable {
     public var welcomeCard: ConciergeWelcomeCardBehavior?
     public var feedback: ConciergeFeedbackBehavior?
     public var citations: ConciergeCitationsBehavior?
+    public var promptSuggestions: ConciergePromptSuggestionsBehavior?
 
     private enum CodingKeys: String, CodingKey {
         case multimodalCarousel
@@ -262,6 +290,7 @@ public struct ConciergeBehaviorConfig: Codable {
         case welcomeCard
         case feedback
         case citations
+        case promptSuggestions
     }
 
     public init(
@@ -272,7 +301,8 @@ public struct ConciergeBehaviorConfig: Codable {
         productCard: ConciergeProductCardBehavior = ConciergeProductCardBehavior(),
         welcomeCard: ConciergeWelcomeCardBehavior? = nil,
         feedback: ConciergeFeedbackBehavior? = nil,
-        citations: ConciergeCitationsBehavior? = nil
+        citations: ConciergeCitationsBehavior? = nil,
+        promptSuggestions: ConciergePromptSuggestionsBehavior? = nil
     ) {
         self.multimodalCarousel = multimodalCarousel
         self.input = input
@@ -282,6 +312,7 @@ public struct ConciergeBehaviorConfig: Codable {
         self.welcomeCard = welcomeCard
         self.feedback = feedback
         self.citations = citations
+        self.promptSuggestions = promptSuggestions
     }
 
     public init(from decoder: Decoder) throws {
@@ -300,6 +331,7 @@ public struct ConciergeBehaviorConfig: Codable {
         welcomeCard = try container.decodeIfPresent(ConciergeWelcomeCardBehavior.self, forKey: .welcomeCard)
         feedback = try container.decodeIfPresent(ConciergeFeedbackBehavior.self, forKey: .feedback)
         citations = try container.decodeIfPresent(ConciergeCitationsBehavior.self, forKey: .citations)
+        promptSuggestions = try container.decodeIfPresent(ConciergePromptSuggestionsBehavior.self, forKey: .promptSuggestions)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -312,5 +344,6 @@ public struct ConciergeBehaviorConfig: Codable {
         try container.encodeIfPresent(welcomeCard, forKey: .welcomeCard)
         try container.encodeIfPresent(feedback, forKey: .feedback)
         try container.encodeIfPresent(citations, forKey: .citations)
+        try container.encodeIfPresent(promptSuggestions, forKey: .promptSuggestions)
     }
 }

--- a/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeColors.swift
+++ b/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeColors.swift
@@ -40,14 +40,15 @@ public struct ConciergeSurfaceColors: Codable {
 public struct ConciergeMessageColors: Codable {
     public var userBackground: CodableColor
     public var userText: CodableColor
-    public var conciergeBackground: CodableColor
+    /// Concierge message bubble background. When nil, falls back to `primary.container` then system default.
+    public var conciergeBackground: CodableColor?
     public var conciergeText: CodableColor
     public var conciergeLink: CodableColor
 
     public init(
         userBackground: CodableColor = CodableColor(Color(UIColor.secondarySystemBackground)),
         userText: CodableColor = CodableColor(Color.primary),
-        conciergeBackground: CodableColor = CodableColor(Color(UIColor.systemBackground)),
+        conciergeBackground: CodableColor? = nil,
         conciergeText: CodableColor = CodableColor(Color.primary),
         conciergeLink: CodableColor = CodableColor(Color.accentColor)
     ) {
@@ -191,7 +192,8 @@ public struct ConciergePrimaryColors: Codable {
 
 /// Product card color tokens (used by the productDetail card style)
 public struct ConciergeProductCardColors: Codable {
-    public var backgroundColor: CodableColor
+    /// Card background. When nil, falls back to `primary.container` then white.
+    public var backgroundColor: CodableColor?
     public var titleColor: CodableColor
     public var subtitleColor: CodableColor
     public var priceColor: CodableColor
@@ -201,7 +203,7 @@ public struct ConciergeProductCardColors: Codable {
     public var outlineColor: CodableColor
 
     public init(
-        backgroundColor: CodableColor = CodableColor(Color.white),
+        backgroundColor: CodableColor? = nil,
         titleColor: CodableColor = CodableColor(Color.primary),
         subtitleColor: CodableColor = CodableColor(Color.primary),
         priceColor: CodableColor = CodableColor(Color.primary),

--- a/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeColors.swift
+++ b/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeColors.swift
@@ -172,15 +172,20 @@ public struct ConciergePrimaryColors: Codable {
     public var primary: CodableColor
     public var secondary: CodableColor
     public var text: CodableColor
+    /// Background for cards and container elements (prompt suggestion chips, product cards, message bubble fallback).
+    /// Configurable via `--color-container`. When nil, falls back to hardcoded light/dark system values.
+    public var container: CodableColor?
 
     public init(
         primary: CodableColor = CodableColor(Color.accentColor),
         secondary: CodableColor = CodableColor(Color.accentColor),
-        text: CodableColor = CodableColor(Color.primary)
+        text: CodableColor = CodableColor(Color.primary),
+        container: CodableColor? = nil
     ) {
         self.primary = primary
         self.secondary = secondary
         self.text = text
+        self.container = container
     }
 }
 
@@ -246,6 +251,7 @@ public struct ConciergeThemeColors: Codable {
     public var productCard: ConciergeProductCardColors
     public var ctaButton: ConciergeCtaButtonColors
     public var welcomePrompt: ConciergeWelcomePromptColors
+    public var promptSuggestion: ConciergeWelcomePromptColors
 
     public init(
         primary: ConciergePrimaryColors = ConciergePrimaryColors(),
@@ -258,7 +264,8 @@ public struct ConciergeThemeColors: Codable {
         disclaimer: CodableColor = CodableColor(Color(UIColor.systemGray)),
         productCard: ConciergeProductCardColors = ConciergeProductCardColors(),
         ctaButton: ConciergeCtaButtonColors = ConciergeCtaButtonColors(),
-        welcomePrompt: ConciergeWelcomePromptColors = ConciergeWelcomePromptColors()
+        welcomePrompt: ConciergeWelcomePromptColors = ConciergeWelcomePromptColors(),
+        promptSuggestion: ConciergeWelcomePromptColors = ConciergeWelcomePromptColors()
     ) {
         self.primary = primary
         self.surface = surface
@@ -271,5 +278,6 @@ public struct ConciergeThemeColors: Codable {
         self.productCard = productCard
         self.ctaButton = ctaButton
         self.welcomePrompt = welcomePrompt
+        self.promptSuggestion = promptSuggestion
     }
 }

--- a/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeContent.swift
+++ b/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeContent.swift
@@ -81,6 +81,7 @@ public struct ConciergeCopy: Codable {
     public var headerSubtitle: String
     public var sourcesLabel: String
     public var feedbackHelpfulLabel: String
+    public var suggestionsHeader: String
 
     enum CodingKeys: String, CodingKey {
         case welcomeHeading = "welcome.heading"
@@ -111,6 +112,7 @@ public struct ConciergeCopy: Codable {
         case headerSubtitle = "header.subtitle"
         case sourcesLabel = "sourcesLabel"
         case feedbackHelpfulLabel = "feedbackHelpfulLabel"
+        case suggestionsHeader = "suggestions.header"
     }
 
     public init(
@@ -141,7 +143,8 @@ public struct ConciergeCopy: Codable {
         headerTitle: String = "",
         headerSubtitle: String = "",
         sourcesLabel: String = "Sources",
-        feedbackHelpfulLabel: String = "Was this helpful?"
+        feedbackHelpfulLabel: String = "Was this helpful?",
+        suggestionsHeader: String = "Suggestions"
     ) {
         self.welcomeHeading = welcomeHeading
         self.welcomeSubheading = welcomeSubheading
@@ -171,6 +174,7 @@ public struct ConciergeCopy: Codable {
         self.headerSubtitle = headerSubtitle
         self.sourcesLabel = sourcesLabel
         self.feedbackHelpfulLabel = feedbackHelpfulLabel
+        self.suggestionsHeader = suggestionsHeader
     }
 
     /// To-do: Move strings to a defaults file and load from there instead of hardcoding in the init.
@@ -204,6 +208,7 @@ public struct ConciergeCopy: Codable {
         headerSubtitle = try container.decodeIfPresent(String.self, forKey: .headerSubtitle) ?? ""
         sourcesLabel = try container.decodeIfPresent(String.self, forKey: .sourcesLabel) ?? "Sources"
         feedbackHelpfulLabel = try container.decodeIfPresent(String.self, forKey: .feedbackHelpfulLabel) ?? "Was this helpful?"
+        suggestionsHeader = try container.decodeIfPresent(String.self, forKey: .suggestionsHeader) ?? "Suggestions"
     }
 }
 

--- a/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeLayout.swift
+++ b/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeLayout.swift
@@ -81,6 +81,7 @@ public struct ConciergeLayout: Codable {
     public var welcomePromptsTopSpacing: CGFloat?
     public var welcomePromptPadding: CGFloat?
     public var welcomePromptCornerRadius: CGFloat?
+    public var suggestionItemBorderRadius: CGFloat?
 
     public init(
         inputHeight: CGFloat = 52,
@@ -155,7 +156,8 @@ public struct ConciergeLayout: Codable {
         welcomeTitleBottomSpacing: CGFloat? = nil,
         welcomePromptsTopSpacing: CGFloat? = nil,
         welcomePromptPadding: CGFloat? = nil,
-        welcomePromptCornerRadius: CGFloat? = nil
+        welcomePromptCornerRadius: CGFloat? = nil,
+        suggestionItemBorderRadius: CGFloat? = nil
     ) {
         self.inputHeight = inputHeight
         self.inputBorderRadius = inputBorderRadius
@@ -220,6 +222,7 @@ public struct ConciergeLayout: Codable {
         self.welcomePromptsTopSpacing = welcomePromptsTopSpacing
         self.welcomePromptPadding = welcomePromptPadding
         self.welcomePromptCornerRadius = welcomePromptCornerRadius
+        self.suggestionItemBorderRadius = suggestionItemBorderRadius
     }
 }
 

--- a/AEPBrandConcierge/Sources/Theme/ThemeCSSMapper.swift
+++ b/AEPBrandConcierge/Sources/Theme/ThemeCSSMapper.swift
@@ -29,6 +29,7 @@ public enum CSSKeyMapper {
         // Colors - Primary
         "color-primary": { cssValue, theme in theme.colors.primary.primary = CSSValueConverter.parseColor(cssValue) },
         "color-text": { cssValue, theme in theme.colors.primary.text = CSSValueConverter.parseColor(cssValue) },
+        "color-container": { cssValue, theme in theme.colors.primary.container = CSSValueConverter.parseColor(cssValue) },
 
         // Colors - Surface
         "main-container-background": { cssValue, theme in theme.colors.surface.mainContainerBackground = CSSValueConverter.parseColor(cssValue) },
@@ -203,6 +204,10 @@ public enum CSSKeyMapper {
         "welcome-prompt-background-color": { cssValue, theme in theme.colors.welcomePrompt.backgroundColor = CSSValueConverter.parseColor(cssValue) },
         "welcome-prompt-text-color": { cssValue, theme in theme.colors.welcomePrompt.textColor = CSSValueConverter.parseColor(cssValue) },
 
+        // Colors - Prompt Suggestions
+        "suggestion-background-color": { cssValue, theme in theme.colors.promptSuggestion.backgroundColor = CSSValueConverter.parseColor(cssValue) },
+        "suggestion-text-color": { cssValue, theme in theme.colors.promptSuggestion.textColor = CSSValueConverter.parseColor(cssValue) },
+
         // Layout - Welcome Screen
         "header-title-font-size": { cssValue, theme in theme.layout.headerTitleFontSize = CSSValueConverter.parsePxValue(cssValue) },
         "welcome-title-font-size": { cssValue, theme in theme.layout.welcomeTitleFontSize = CSSValueConverter.parsePxValue(cssValue) },
@@ -214,6 +219,7 @@ public enum CSSKeyMapper {
         "welcome-prompts-top-spacing": { cssValue, theme in theme.layout.welcomePromptsTopSpacing = CSSValueConverter.parsePxValue(cssValue) },
         "welcome-prompt-padding": { cssValue, theme in theme.layout.welcomePromptPadding = CSSValueConverter.parsePxValue(cssValue) },
         "welcome-prompt-corner-radius": { cssValue, theme in theme.layout.welcomePromptCornerRadius = CSSValueConverter.parsePxValue(cssValue) },
+        "suggestion-item-border-radius": { cssValue, theme in theme.layout.suggestionItemBorderRadius = CSSValueConverter.parsePxValue(cssValue) },
     ]
 
     /// Returns the normalized CSS keys (without the leading `--`) that are supported by iOS.

--- a/AEPBrandConcierge/Sources/Views/Chat/Messages/ConciergeResponsePlaceholderView.swift
+++ b/AEPBrandConcierge/Sources/Views/Chat/Messages/ConciergeResponsePlaceholderView.swift
@@ -42,7 +42,11 @@ struct ConciergeResponsePlaceholderView: View {
         .padding(.vertical, 10)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(theme.colors.message.conciergeBackground.color)
+                .fill(
+                    theme.colors.message.conciergeBackground?.color
+                        ?? theme.colors.primary.container?.color
+                        ?? Color(UIColor.systemBackground)
+                )
         )
     }
 }

--- a/AEPBrandConcierge/Sources/Views/Chat/Messages/MessageListView.swift
+++ b/AEPBrandConcierge/Sources/Views/Chat/Messages/MessageListView.swift
@@ -32,7 +32,20 @@ struct MessageListView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     VStack(spacing: 12) {
-                        ForEach(messages) { message in
+                        ForEach(Array(messages.enumerated()), id: \.element.id) { index, message in
+                            // showHeader: insert a "Suggestions" label above the first chip in a group
+                            if isFirstInSuggestionGroup(at: index),
+                               theme.behavior.promptSuggestions?.showHeader == true {
+                                HStack {
+                                    Text(theme.text.suggestionsHeader)
+                                        .font(.system(.subheadline).weight(.semibold))
+                                        .foregroundColor(theme.colors.message.conciergeText.color)
+                                    Spacer()
+                                }
+                                .padding(.horizontal, horizontalPadding(for: message.template))
+                                .padding(.bottom, -4)
+                            }
+
                             ChatMessageView(
                                 messageId: message.id,
                                 template: message.template,
@@ -80,6 +93,8 @@ struct MessageListView: View {
     ///
     /// Carousel messages use `productCardCarouselHorizontalPadding` when set,
     /// falling back to `chatHistoryPadding` when not configured.
+    /// Prompt suggestion chips use the default inset unless `alignToMessage` is true,
+    /// in which case they align to the message bubble content edge.
     /// All other messages use `chatHistoryPadding` plus the base scroll content padding
     /// to preserve the original combined inset.
     private func horizontalPadding(for template: MessageTemplate) -> CGFloat {
@@ -87,6 +102,20 @@ struct MessageListView: View {
             return theme.layout.productCardCarouselHorizontalPadding
                 ?? theme.layout.chatHistoryPadding
         }
+        if case .promptSuggestion = template,
+           theme.behavior.promptSuggestions?.alignToMessage == true {
+            // Align to message bubble: match the bubble's horizontal inset (padding + message padding)
+            return theme.layout.chatHistoryPadding + Self.scrollContentBasePadding
+                + theme.layout.messagePadding.leading
+        }
         return theme.layout.chatHistoryPadding + Self.scrollContentBasePadding
+    }
+
+    /// Returns true when the message at `index` is a `promptSuggestion` and the preceding message is not.
+    private func isFirstInSuggestionGroup(at index: Int) -> Bool {
+        guard case .promptSuggestion = messages[index].template else { return false }
+        if index == 0 { return true }
+        if case .promptSuggestion = messages[index - 1].template { return false }
+        return true
     }
 }

--- a/AEPBrandConcierge/Sources/Views/Chat/Messages/SourcesListView.swift
+++ b/AEPBrandConcierge/Sources/Views/Chat/Messages/SourcesListView.swift
@@ -110,7 +110,11 @@ public struct SourcesListView: View {
 
     private var backgroundShape: some View {
         RoundedCornerShape(radius: theme.layout.messageBorderRadius, corners: [.bottomLeft, .bottomRight])
-            .fill(theme.colors.message.conciergeBackground.color)
+            .fill(
+                theme.colors.message.conciergeBackground?.color
+                    ?? theme.colors.primary.container?.color
+                    ?? Color(UIColor.systemBackground)
+            )
     }
 
     private var thumbsInline: Bool {

--- a/AEPBrandConcierge/Sources/Views/ChatMessageView.swift
+++ b/AEPBrandConcierge/Sources/Views/ChatMessageView.swift
@@ -355,26 +355,33 @@ struct ChatMessageView: View {
             CarouselGroupView(items: items)
 
         case .promptSuggestion(let text):
+            let suggestionTextColor = theme.colors.promptSuggestion.textColor?.color
+                ?? theme.colors.message.conciergeText.color
+            let suggestionBgColor = theme.colors.promptSuggestion.backgroundColor?.color
+                ?? theme.colors.primary.container?.color
+                ?? Color(UIColor.secondarySystemBackground)
+            let suggestionCornerRadius = theme.layout.suggestionItemBorderRadius ?? 10
+            let suggestionMaxLines = theme.behavior.promptSuggestions?.itemMaxLines ?? 1
+
             HStack(alignment: .bottom) {
-                Group {
-                    Button(action: { onSuggestionTap?(text) }) {
-                        HStack(spacing: 8) {
-                            Image(systemName: "arrowshape.turn.up.right")
-                                .imageScale(.small)
-                                .foregroundColor(theme.colors.message.conciergeText.color)
-                            Text(text)
-                                .font(.system(.subheadline))
-                                .foregroundColor(theme.colors.message.conciergeText.color)
-                        }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 12)
-                        .background(
-                            RoundedRectangle(cornerRadius: theme.layout.messageBorderRadius, style: .continuous)
-                                .fill(theme.colors.message.conciergeBackground.color)
-                        )
+                Button(action: { onSuggestionTap?(text) }) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "arrow.turn.down.right")
+                            .imageScale(.small)
+                            .foregroundColor(suggestionTextColor)
+                        Text(text)
+                            .font(.system(.subheadline))
+                            .foregroundColor(suggestionTextColor)
+                            .lineLimit(suggestionMaxLines)
                     }
-                    .buttonStyle(PlainButtonStyle())
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: suggestionCornerRadius, style: .continuous)
+                            .fill(suggestionBgColor)
+                    )
                 }
+                .buttonStyle(PlainButtonStyle())
                 Spacer()
             }
         }

--- a/AEPBrandConcierge/Sources/Views/ChatMessageView.swift
+++ b/AEPBrandConcierge/Sources/Views/ChatMessageView.swift
@@ -171,6 +171,9 @@ struct ChatMessageView: View {
             let displayedSources = decoration?.deduplicatedSources ?? CitationRenderer.deduplicate(rawSources)
 
             let alignment: HorizontalAlignment = theme.behavior.chat.messageAlignment == .center ? .center : .leading
+            let conciergeBackgroundColor = theme.colors.message.conciergeBackground?.color
+                ?? theme.colors.primary.container?.color
+                ?? Color(UIColor.systemBackground)
 
             VStack(alignment: alignment, spacing: 0) {
                 HStack(alignment: .bottom) {
@@ -218,10 +221,10 @@ struct ChatMessageView: View {
                                 } else {
                                     if !displayedSources.isEmpty {
                                         RoundedCornerShape(radius: theme.layout.messageBorderRadius, corners: [.topLeft, .topRight])
-                                            .fill(theme.colors.message.conciergeBackground.color)
+                                            .fill(conciergeBackgroundColor)
                                     } else {
                                         RoundedRectangle(cornerRadius: theme.layout.messageBorderRadius, style: .continuous)
-                                            .fill(theme.colors.message.conciergeBackground.color)
+                                            .fill(conciergeBackgroundColor)
                                     }
                                 }
                             }
@@ -496,7 +499,11 @@ private extension ChatMessageView {
             .padding(14)
             .frame(width: 350, alignment: .leading)
         }
-        .background(theme.colors.message.conciergeBackground.color)
+        .background(
+            theme.colors.message.conciergeBackground?.color
+                ?? theme.colors.primary.container?.color
+                ?? Color(UIColor.systemBackground)
+        )
         .cornerRadius(theme.layout.borderRadiusCard)
         .shadow(
             color: theme.layout.multimodalCardBoxShadow.isEnabled ? theme.layout.multimodalCardBoxShadow.color.color : .clear,

--- a/AEPBrandConcierge/Sources/Views/ChatView.swift
+++ b/AEPBrandConcierge/Sources/Views/ChatView.swift
@@ -227,7 +227,11 @@ public struct ChatView: View {
                     .padding(.vertical, 10)
                     .background(
                         RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .fill(theme.colors.message.conciergeBackground.color.opacity(0.96))
+                            .fill(
+                                (theme.colors.message.conciergeBackground?.color
+                                    ?? theme.colors.primary.container?.color
+                                    ?? Color(UIColor.systemBackground)).opacity(0.96)
+                            )
                     )
                     .padding(.top, 12)
                     .padding(.horizontal, 16)

--- a/AEPBrandConcierge/Sources/Views/ProductDetailCardView.swift
+++ b/AEPBrandConcierge/Sources/Views/ProductDetailCardView.swift
@@ -52,7 +52,11 @@ struct ProductDetailCardView: View {
         .padding(ProductDetailCardDimensions.contentPadding)
         .frame(width: cardWidth, height: cardHeight)
         .clipped()
-        .background(theme.colors.productCard.backgroundColor.color)
+        .background(
+            theme.colors.productCard.backgroundColor?.color
+                ?? theme.colors.primary.container?.color
+                ?? Color.white
+        )
         .cornerRadius(theme.layout.borderRadiusCard)
         .overlay(
             RoundedRectangle(cornerRadius: theme.layout.borderRadiusCard)

--- a/AEPBrandConcierge/Tests/UnitTests/SnapshotTests/PromptSuggestionChipSnapshotTests.swift
+++ b/AEPBrandConcierge/Tests/UnitTests/SnapshotTests/PromptSuggestionChipSnapshotTests.swift
@@ -1,0 +1,76 @@
+/*
+ Copyright 2026 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import SnapshotTesting
+import SwiftUI
+import XCTest
+
+@testable import AEPBrandConcierge
+
+final class PromptSuggestionChipSnapshotTests: XCTestCase {
+    func test_promptSuggestionChip_defaultTheme() {
+        let view = PromptSuggestionChipProbeHost(theme: ConciergeThemeLoader.default())
+        assertSnapshot(of: view, as: .image(layout: .fixed(width: 390, height: 180)))
+    }
+
+    func test_promptSuggestionChip_customColors() {
+        var probeTheme = ConciergeThemeLoader.default()
+
+        // Apply custom suggestion colors to confirm theming wires through.
+        probeTheme.colors.promptSuggestion.backgroundColor = CodableColor(.indigo)
+        probeTheme.colors.promptSuggestion.textColor = CodableColor(.white)
+        probeTheme.layout.suggestionItemBorderRadius = 20
+
+        let view = PromptSuggestionChipProbeHost(theme: probeTheme)
+        assertSnapshot(of: view, as: .image(layout: .fixed(width: 390, height: 180)))
+    }
+
+    func test_promptSuggestionChip_containerColorFallback() {
+        var probeTheme = ConciergeThemeLoader.default()
+
+        // Leave promptSuggestion.backgroundColor nil; container color should be the fallback.
+        probeTheme.colors.primary.container = CodableColor(.mint)
+
+        let view = PromptSuggestionChipProbeHost(theme: probeTheme)
+        assertSnapshot(of: view, as: .image(layout: .fixed(width: 390, height: 180)))
+    }
+
+    func test_promptSuggestionChip_multiLine() {
+        var probeTheme = ConciergeThemeLoader.default()
+        probeTheme.behavior.promptSuggestions = ConciergePromptSuggestionsBehavior(itemMaxLines: 3)
+
+        let view = PromptSuggestionChipProbeHost(
+            theme: probeTheme,
+            text: "This is a long suggestion that should wrap across multiple lines when itemMaxLines allows it"
+        )
+        assertSnapshot(of: view, as: .image(layout: .fixed(width: 390, height: 180)))
+    }
+}
+
+private struct PromptSuggestionChipProbeHost: View {
+    let theme: ConciergeTheme
+    var text: String = "Show me some examples"
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ChatMessageView(
+                template: .promptSuggestion(text)
+            )
+
+            Spacer(minLength: 0)
+        }
+        .padding(16)
+        .frame(width: 390, height: 180, alignment: .top)
+        .background(Color.white)
+        .conciergeTheme(theme)
+    }
+}

--- a/AEPBrandConcierge/Tests/UnitTests/ThemeCSSMapperTests.swift
+++ b/AEPBrandConcierge/Tests/UnitTests/ThemeCSSMapperTests.swift
@@ -373,7 +373,7 @@ final class ThemeCSSMapperTests: XCTestCase {
         CSSKeyMapper.apply(cssKey: "product-card-background-color", cssValue: "#F5F5F5", to: &theme)
 
         // Then
-        XCTAssertEqual(theme.colors.productCard.backgroundColor.color.toHexString(), "#F5F5F5")
+        XCTAssertEqual(theme.colors.productCard.backgroundColor!.color.toHexString(), "#F5F5F5")
     }
 
     func test_productCardTitleColor_mapsToProductCardColors() {
@@ -778,6 +778,7 @@ final class ThemeCSSMapperTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(theme.colors.primary.container)
+        XCTAssertEqual(theme.colors.primary.container?.color.toHexString(), "#F0F0F0")
     }
 
     func test_suggestionBackgroundColor_mapsToColors() {
@@ -789,6 +790,7 @@ final class ThemeCSSMapperTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(theme.colors.promptSuggestion.backgroundColor)
+        XCTAssertEqual(theme.colors.promptSuggestion.backgroundColor?.color.toHexString(), "#F0F0F0")
     }
 
     func test_suggestionTextColor_mapsToColors() {
@@ -800,6 +802,7 @@ final class ThemeCSSMapperTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(theme.colors.promptSuggestion.textColor)
+        XCTAssertEqual(theme.colors.promptSuggestion.textColor?.color.toHexString(), "#131313")
     }
 
     func test_suggestionItemBorderRadius_mapsToLayout() {

--- a/AEPBrandConcierge/Tests/UnitTests/ThemeCSSMapperTests.swift
+++ b/AEPBrandConcierge/Tests/UnitTests/ThemeCSSMapperTests.swift
@@ -766,5 +766,51 @@ final class ThemeCSSMapperTests: XCTestCase {
         // Then
         XCTAssertEqual(theme.layout.ctaButtonIconSize, 16)
     }
+
+    // MARK: - Prompt Suggestions CSS Key Tests
+
+    func test_colorContainer_mapsToColors() {
+        // Given
+        var theme = ConciergeTheme()
+
+        // When
+        CSSKeyMapper.apply(cssKey: "--color-container", cssValue: "#F0F0F0", to: &theme)
+
+        // Then
+        XCTAssertNotNil(theme.colors.primary.container)
+    }
+
+    func test_suggestionBackgroundColor_mapsToColors() {
+        // Given
+        var theme = ConciergeTheme()
+
+        // When
+        CSSKeyMapper.apply(cssKey: "--suggestion-background-color", cssValue: "#F0F0F0", to: &theme)
+
+        // Then
+        XCTAssertNotNil(theme.colors.promptSuggestion.backgroundColor)
+    }
+
+    func test_suggestionTextColor_mapsToColors() {
+        // Given
+        var theme = ConciergeTheme()
+
+        // When
+        CSSKeyMapper.apply(cssKey: "--suggestion-text-color", cssValue: "#131313", to: &theme)
+
+        // Then
+        XCTAssertNotNil(theme.colors.promptSuggestion.textColor)
+    }
+
+    func test_suggestionItemBorderRadius_mapsToLayout() {
+        // Given
+        var theme = ConciergeTheme()
+
+        // When
+        CSSKeyMapper.apply(cssKey: "--suggestion-item-border-radius", cssValue: "10px", to: &theme)
+
+        // Then
+        XCTAssertEqual(theme.layout.suggestionItemBorderRadius, 10)
+    }
 }
 

--- a/AEPBrandConcierge/Tests/UnitTests/ThemeDecodingTests.swift
+++ b/AEPBrandConcierge/Tests/UnitTests/ThemeDecodingTests.swift
@@ -435,7 +435,7 @@ final class ThemeDecodingTests: XCTestCase {
         }
         
         // Then
-        XCTAssertEqual(theme.colors.productCard.backgroundColor.color.toHexString(), "#FFFFFF")
+        XCTAssertEqual(theme.colors.productCard.backgroundColor!.color.toHexString(), "#FFFFFF")
         XCTAssertEqual(theme.colors.productCard.titleColor.color.toHexString(), "#292929")
         XCTAssertEqual(theme.colors.productCard.subtitleColor.color.toHexString(), "#292929")
         XCTAssertEqual(theme.colors.productCard.priceColor.color.toHexString(), "#292929")
@@ -656,6 +656,28 @@ final class ThemeDecodingTests: XCTestCase {
         let decoded = try JSONDecoder().decode(ConciergeTheme.self, from: data)
 
         XCTAssertEqual(decoded.text.suggestionsHeader, "Suggestions")
+    }
+
+    // MARK: - primary.container defaults
+
+    func test_primaryColors_container_defaultsToNil() {
+        let theme = ConciergeTheme()
+        XCTAssertNil(theme.colors.primary.container)
+    }
+
+    func test_promptSuggestion_backgroundColor_defaultsToNil() {
+        let theme = ConciergeTheme()
+        XCTAssertNil(theme.colors.promptSuggestion.backgroundColor)
+    }
+
+    func test_message_conciergeBackground_defaultsToNil() {
+        let theme = ConciergeTheme()
+        XCTAssertNil(theme.colors.message.conciergeBackground)
+    }
+
+    func test_productCard_backgroundColor_defaultsToNil() {
+        let theme = ConciergeTheme()
+        XCTAssertNil(theme.colors.productCard.backgroundColor)
     }
 
 }

--- a/AEPBrandConcierge/Tests/UnitTests/ThemeDecodingTests.swift
+++ b/AEPBrandConcierge/Tests/UnitTests/ThemeDecodingTests.swift
@@ -567,17 +567,96 @@ final class ThemeDecodingTests: XCTestCase {
             XCTFail("Theme should be loaded")
             return
         }
-        
+
         // When
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted]
         let encodedData = try encoder.encode(theme)
-        
+
         // Then
         XCTAssertNotNil(encodedData)
         let jsonObject = try JSONSerialization.jsonObject(with: encodedData, options: [])
         XCTAssertTrue(jsonObject is [String: Any])
     }
-    
+
+    // MARK: - Prompt Suggestions Behavior Decoding Tests
+
+    func test_behavior_promptSuggestions_decodesCorrectly() throws {
+        let json = """
+        {
+          "behavior": {
+            "promptSuggestions": {
+              "itemMaxLines": 2,
+              "showHeader": true,
+              "alignToMessage": true
+            }
+          }
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(ConciergeTheme.self, from: data)
+
+        XCTAssertEqual(decoded.behavior.promptSuggestions?.itemMaxLines, 2)
+        XCTAssertEqual(decoded.behavior.promptSuggestions?.showHeader, true)
+        XCTAssertEqual(decoded.behavior.promptSuggestions?.alignToMessage, true)
+    }
+
+    func test_behavior_promptSuggestions_absentBlock_isNil() throws {
+        let json = """
+        { "behavior": {} }
+        """
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(ConciergeTheme.self, from: data)
+
+        XCTAssertNil(decoded.behavior.promptSuggestions)
+    }
+
+    func test_behavior_promptSuggestions_defaults() {
+        let behavior = ConciergePromptSuggestionsBehavior()
+        XCTAssertEqual(behavior.itemMaxLines, 1)
+        XCTAssertFalse(behavior.showHeader)
+        XCTAssertFalse(behavior.alignToMessage)
+    }
+
+    func test_behavior_promptSuggestions_partialJson_usesDefaults() throws {
+        let json = """
+        {
+          "behavior": {
+            "promptSuggestions": {
+              "showHeader": true
+            }
+          }
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(ConciergeTheme.self, from: data)
+
+        XCTAssertEqual(decoded.behavior.promptSuggestions?.itemMaxLines, 1)
+        XCTAssertEqual(decoded.behavior.promptSuggestions?.showHeader, true)
+        XCTAssertEqual(decoded.behavior.promptSuggestions?.alignToMessage, false)
+    }
+
+    // MARK: - suggestions.header Text String Tests
+
+    func test_text_suggestionsHeader_decodesCorrectly() throws {
+        let json = """
+        { "text": { "suggestions.header": "Explore More" } }
+        """
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(ConciergeTheme.self, from: data)
+
+        XCTAssertEqual(decoded.text.suggestionsHeader, "Explore More")
+    }
+
+    func test_text_suggestionsHeader_defaultsToSuggestions() throws {
+        let json = """
+        { "text": {} }
+        """
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(ConciergeTheme.self, from: data)
+
+        XCTAssertEqual(decoded.text.suggestionsHeader, "Suggestions")
+    }
+
 }
 

--- a/AEPBrandConcierge/Tests/UnitTests/ThemeKeyCoverageTests.swift
+++ b/AEPBrandConcierge/Tests/UnitTests/ThemeKeyCoverageTests.swift
@@ -271,6 +271,13 @@ private extension ThemeKeyCoverageTests {
         "welcome-prompt-background-color": "colors.welcomePrompt.backgroundColor",
         "welcome-prompt-text-color": "colors.welcomePrompt.textColor",
 
+        // Colors - Prompt Suggestions
+        "suggestion-background-color": "colors.promptSuggestion.backgroundColor",
+        "suggestion-text-color": "colors.promptSuggestion.textColor",
+
+        // Colors - Container
+        "color-container": "colors.primary.container",
+
         // Layout - Welcome Screen
         "header-title-font-size": "layout.headerTitleFontSize",
         "welcome-title-font-size": "layout.welcomeTitleFontSize",
@@ -282,6 +289,9 @@ private extension ThemeKeyCoverageTests {
         "welcome-prompts-top-spacing": "layout.welcomePromptsTopSpacing",
         "welcome-prompt-padding": "layout.welcomePromptPadding",
         "welcome-prompt-corner-radius": "layout.welcomePromptCornerRadius",
+
+        // Layout - Prompt Suggestions
+        "suggestion-item-border-radius": "layout.suggestionItemBorderRadius",
     ]
 
     // MARK: - Theme token model reflection

--- a/ConciergeDemoApp/theme-all-properties.json
+++ b/ConciergeDemoApp/theme-all-properties.json
@@ -41,6 +41,11 @@
     },
     "productCard": {
       "cardStyle": "productDetail"
+    },
+    "promptSuggestions": {
+      "itemMaxLines": 1,
+      "showHeader": true,
+      "alignToMessage": true
     }
   },
   "disclaimer": {
@@ -81,7 +86,8 @@
     "header.title": "",
     "header.subtitle": "",
     "sourcesLabel": "Sources",
-    "feedbackHelpfulLabel": "Was this helpful?"
+    "feedbackHelpfulLabel": "Was this helpful?",
+    "suggestions.header": "Suggestions"
   },
   "arrays": {
     "welcome.examples": [
@@ -132,12 +138,16 @@
     "--welcome-prompt-corner-radius": "20px",
     "--welcome-prompt-background-color": "#D3D3D3",
     "--welcome-prompt-text-color": "#000000",
+    "--suggestion-background-color": "#F0F0F0",
+    "--suggestion-text-color": "#131313",
+    "--suggestion-item-border-radius": "60px",
 
     "--font-family": "",
     "--line-height-body": "1.5",
 
     "--color-primary": "#006554",
     "--color-text": "#131313",
+    "--color-container": "#F0F0F0",
     "--main-container-background": "#FFFFFF",
     "--main-container-bottom-background": "#FFFFFF",
     "--message-blocker-background": "#FFFFFF",

--- a/Documentation/Implementation/style-guide.md
+++ b/Documentation/Implementation/style-guide.md
@@ -236,6 +236,14 @@ Feature toggles and interaction configuration.
 | `behavior.welcomeCard.promptMaxLines` | number | `3` | Maximum number of text lines shown in prompt suggestion cards. |
 | `behavior.welcomeCard.contentAlignment` | string | `"top"` | Vertical alignment of welcome content. `"center"` centers content vertically, `"top"` aligns to top. |
 
+### Prompt Suggestions
+
+| JSON Key | Type | Default | Description |
+|----------|------|---------|-------------|
+| `behavior.promptSuggestions.itemMaxLines` | number | `1` | Max lines for suggestion chip text before ellipsis. |
+| `behavior.promptSuggestions.showHeader` | boolean | `false` | Show a "Suggestions" header label above the chips. Label text is configurable via `text["suggestions.header"]`. |
+| `behavior.promptSuggestions.alignToMessage` | boolean | `false` | Align the suggestion chips to the message bubble content edge. When `false`, uses the default chat padding offset. |
+
 ### Feedback
 
 | JSON Key | Type | Default | Description |
@@ -285,6 +293,11 @@ Feature toggles and interaction configuration.
       "promptFullWidth": true,
       "promptMaxLines": 3,
       "contentAlignment": "top"
+    },
+    "promptSuggestions": {
+      "itemMaxLines": 1,
+      "showHeader": false,
+      "alignToMessage": false
     },
     "feedback": {
       "displayMode": "modal",
@@ -403,6 +416,14 @@ While there are no strict requirements for character limits in many of these tex
 | `text["sourcesLabel"]` | `"Sources"` | Label text for the sources accordion header |
 | `text["feedbackHelpfulLabel"]` | `"Was this helpful?"` | Label shown above feedback thumbs when `behavior.feedback.thumbsPlacement` is `"below"` |
 
+### Prompt Suggestions
+
+| JSON Key | Default | Description |
+|----------|---------|-------------|
+| `text["suggestions.header"]` | `"Suggestions"` | Header label shown above prompt suggestion chips when `behavior.promptSuggestions.showHeader` is `true`. |
+
+> **Tip:** To hide the header subtitle, set `text["header.subtitle"]` to `""`. The subtitle is automatically hidden when its text is blank.
+
 ### Example
 
 ```json
@@ -513,6 +534,7 @@ Visual styling using CSS-like variable names. All properties in the `theme` obje
 |--------------|----------------|------|---------|-------------|
 | `--color-primary` | `colors.primary.primary` | `Color` | `accentColor` | Primary brand color |
 | `--color-text` | `colors.primary.text` | `Color` | `primary` | Primary text color |
+| `--color-container` | `colors.primary.container` | `Color?` | `nil` (falls back to `secondarySystemBackground`) | Background for cards and container elements — prompt suggestion chips, product cards, message bubble fallback. |
 
 ### Colors - Surface
 
@@ -571,6 +593,13 @@ Visual styling using CSS-like variable names. All properties in the `theme` obje
 | `--welcome-prompt-background-color` | `colors.welcomePrompt.backgroundColor` | `Color?` | `nil` | Welcome prompt card background. Falls back to card's `backgroundColor` from `arrays["welcome.examples"]`. |
 | `--welcome-prompt-text-color` | `colors.welcomePrompt.textColor` | `Color?` | `nil` | Welcome prompt text color. Falls back to `--color-text`. |
 
+### Colors - Prompt Suggestions
+
+| CSS Variable | Swift Property | Type | Default | Description |
+|--------------|----------------|------|---------|-------------|
+| `--suggestion-background-color` | `colors.promptSuggestion.backgroundColor` | `Color?` | `nil` (falls back to `--color-container` then `secondarySystemBackground`) | Prompt suggestion chip background color. |
+| `--suggestion-text-color` | `colors.promptSuggestion.textColor` | `Color?` | `nil` (falls back to `--message-concierge-text`) | Prompt suggestion chip text and icon color. |
+
 ### Colors - Citations
 
 | CSS Variable | Swift Property | Type | Default | Description |
@@ -610,6 +639,8 @@ Visual styling using CSS-like variable names. All properties in the `theme` obje
 | CSS Variable | Swift Property | Type | Default | Description |
 |--------------|----------------|------|---------|-------------|
 | `--disclaimer-color` | `colors.disclaimer` | `Color` | `systemGray` | Disclaimer text color |
+
+> **Layout value format:** All layout measurements are specified as CSS strings in the JSON theme object (e.g. `"8px"`, `"16px"`) and integer quantities as numeric strings (e.g. `"700"`, `"400"`). The SDK parses these into their internal Swift types (`CGFloat` for point values, `Int` for weights and orders). The **Type** and **Default** columns below reflect the internal representation.
 
 ### Layout - Input
 
@@ -734,6 +765,7 @@ Visual styling using CSS-like variable names. All properties in the `theme` obje
 | `--welcome-prompts-top-spacing` | `layout.welcomePromptsTopSpacing` | `CGFloat?` | `nil` | Spacing above the prompt suggestions section. |
 | `--welcome-prompt-padding` | `layout.welcomePromptPadding` | `CGFloat?` | `nil` | Padding around each prompt suggestion card. |
 | `--welcome-prompt-corner-radius` | `layout.welcomePromptCornerRadius` | `CGFloat?` | `nil` | Corner radius of prompt suggestion cards. Falls back to `--border-radius-card`. |
+| `--suggestion-item-border-radius` | `layout.suggestionItemBorderRadius` | `CGFloat?` | `nil` (defaults to `10`) | Corner radius of post-response prompt suggestion chips. |
 
 ---
 
@@ -773,6 +805,11 @@ Visual styling using CSS-like variable names. All properties in the `theme` obje
       "promptMaxLines": 3,
       "contentAlignment": "top"
     },
+    "promptSuggestions": {
+      "itemMaxLines": 1,
+      "showHeader": true,
+      "alignToMessage": true
+    },
     "feedback": {
       "displayMode": "modal",
       "thumbsPlacement": "inline"
@@ -806,7 +843,8 @@ Visual styling using CSS-like variable names. All properties in the `theme` obje
     "header.title": "",
     "header.subtitle": "",
     "sourcesLabel": "Sources",
-    "feedbackHelpfulLabel": "Was this helpful?"
+    "feedbackHelpfulLabel": "Was this helpful?",
+    "suggestions.header": "Suggestions"
   },
   "arrays": {
     "welcome.examples": [
@@ -929,6 +967,10 @@ Visual styling using CSS-like variable names. All properties in the `theme` obje
     "--input-send-arrow-background-color": "",
     "--input-mic-icon-color": "",
     "--input-mic-recording-icon-color": "",
+    "--color-container": "#F0F0F0",
+    "--suggestion-background-color": "#F0F0F0",
+    "--suggestion-text-color": "#131313",
+    "--suggestion-item-border-radius": "10px",
     "--welcome-prompt-background-color": "",
     "--welcome-prompt-text-color": "",
     "--welcome-title-font-size": "22px",
@@ -984,6 +1026,9 @@ This section documents which properties are fully implemented, partially impleme
 | `behavior.welcomeCard.promptFullWidth` | ✅ | Controls prompt card layout (full-width vs compact chip) in ChatMessageView |
 | `behavior.welcomeCard.promptMaxLines` | ✅ | Controls max text lines in prompt cards |
 | `behavior.welcomeCard.contentAlignment` | ✅ | Controls welcome content vertical alignment |
+| `behavior.promptSuggestions.itemMaxLines` | ✅ | Controls max text lines for post-response suggestion chips in ChatMessageView |
+| `behavior.promptSuggestions.showHeader` | ✅ | Controls "Suggestions" header visibility above chip group in MessageListView |
+| `behavior.promptSuggestions.alignToMessage` | ✅ | Controls horizontal alignment of chip group in MessageListView |
 | `behavior.feedback.displayMode` | ✅ | Controls feedback presentation: `"modal"` (centered) vs `"action"` (action sheet) in FeedbackOverlayView |
 | `behavior.feedback.thumbsPlacement` | ✅ | Controls thumbs placement (inline vs below) in SourcesListView |
 | `behavior.citations.showLinkIcon` | ✅ | Controls external link icon visibility in SourceRowView |
@@ -1031,6 +1076,7 @@ This section documents which properties are fully implemented, partially impleme
 | `text["header.subtitle"]` | ✅ | Used in ChatTopBar, overrides programmatic subtitle when non-empty |
 | `text["sourcesLabel"]` | ✅ | Used in SourcesListView for accordion header label |
 | `text["feedbackHelpfulLabel"]` | ✅ | Used in SourcesListView when thumbsPlacement is "below" |
+| `text["suggestions.header"]` | ✅ | Used in MessageListView as the header above suggestion chip groups when `behavior.promptSuggestions.showHeader` is `true` |
 
 ### Arrays
 
@@ -1059,6 +1105,9 @@ This section documents which properties are fully implemented, partially impleme
 |--------------|--------|-------|
 | `--color-primary` | ✅ | Used throughout UI |
 | `--color-text` | ✅ | Used for text styling |
+| `--color-container` | ✅ | Background fallback for prompt suggestion chips, product cards, and message bubbles |
+| `--suggestion-background-color` | ✅ | Used in ChatMessageView for suggestion chip background |
+| `--suggestion-text-color` | ✅ | Used in ChatMessageView for suggestion chip text and icon color |
 | `--main-container-background` | ✅ | Used in ChatView, ChatTopBar |
 | `--main-container-bottom-background` | ✅ | Used in ChatComposer |
 | `--message-blocker-background` | ✅ | Used in ChatView |
@@ -1154,6 +1203,7 @@ This section documents which properties are fully implemented, partially impleme
 | `--welcome-prompts-top-spacing` | ✅ | Used in MessageListView for spacing above prompts section |
 | `--welcome-prompt-padding` | ✅ | Used in ChatMessageView for prompt card padding |
 | `--welcome-prompt-corner-radius` | ✅ | Used in ChatMessageView for prompt card corner radius |
+| `--suggestion-item-border-radius` | ✅ | Used in ChatMessageView for post-response suggestion chip corner radius |
 | `--product-card-width` | ✅ | Used in ProductDetailCardView, CarouselGroupView |
 | `--product-card-height` | ✅ | Used in ProductDetailCardView, CarouselGroupView |
 | `--product-card-title-font-size` | ✅ | Used in ProductDetailCardView |

--- a/Documentation/Implementation/style-guide.md
+++ b/Documentation/Implementation/style-guide.md
@@ -360,6 +360,8 @@ While there are no strict requirements for character limits in many of these tex
 | `text["header.title"]` | `""` | Header title text. When non-empty, overrides the programmatic `title` parameter passed to `ChatView`. |
 | `text["header.subtitle"]` | `""` | Header subtitle text. When non-empty, overrides the programmatic `subtitle` parameter passed to `ChatView`. |
 
+> **Tip:** To hide the header subtitle, set `text["header.subtitle"]` to `""`. The subtitle is automatically hidden when its text is blank.
+
 ### Welcome Screen
 
 | JSON Key | Default | Description |
@@ -421,8 +423,6 @@ While there are no strict requirements for character limits in many of these tex
 | JSON Key | Default | Description |
 |----------|---------|-------------|
 | `text["suggestions.header"]` | `"Suggestions"` | Header label shown above prompt suggestion chips when `behavior.promptSuggestions.showHeader` is `true`. |
-
-> **Tip:** To hide the header subtitle, set `text["header.subtitle"]` to `""`. The subtitle is automatically hidden when its text is blank.
 
 ### Example
 


### PR DESCRIPTION
## Description
Adds full theming and behavioral control over prompt suggestion chips, along with a refactor of chip colors to reuse the existing `ConciergeWelcomePromptColors` type.

**New CSS variables:**
- `--color-container` — background color for container elements (chips, cards); maps to `colors.primary.container`
- `--suggestion-background-color` — chip background color; maps to `colors.promptSuggestion.backgroundColor`
- `--suggestion-text-color` — chip text and icon color; maps to `colors.promptSuggestion.textColor`
- `--suggestion-item-border-radius` — chip corner radius; maps to `layout.suggestionItemBorderRadius`

**New behavior config (`behavior.promptSuggestions`):**
- `itemMaxLines` — max lines of chip text before ellipsis (default: `1`)
- `showHeader` — show a configurable header label above the first chip in a group (default: `false`)
- `alignToMessage` — align chips to the inner content edge of the bot message bubble (default: `false`)

**New text string:**
- `text["suggestions.header"]` — label shown above chips when `showHeader` is enabled (default: `"Suggestions"`)

**Other changes:**
- Prompt suggestion chip icon updated from `arrowshape.turn.up.right` to `arrow.turn.down.right` to match design reference
- `promptSuggestion` chip colors refactored to use `ConciergeWelcomePromptColors` (code reuse, removes duplication)
- `ConciergePromptSuggestionsBehavior` uses a custom `init(from:)` with `decodeIfPresent` + defaults to tolerate partial JSON, consistent with all other behavior structs

## Related Issue

## Motivation and Context

## How Has This Been Tested?
- New unit tests added in `ThemeCSSMapperTests` (4 tests), `ThemeDecodingTests` (6 tests including partial JSON and defaults), and `ThemeKeyCoverageTests` (3 new entries)
- All existing unit tests pass
- Verified manually in the demo app using `theme-all-properties.json` (updated with all new properties)

## Screenshots (if appropriate):
<img width="300" height="700" alt="image" src="https://github.com/user-attachments/assets/1dba9e60-a8c9-486b-97b6-a5c88c8db732" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
