### PR TITLE
Fix paragraph identity detection and citation badge spacing

### DIFF
--- a/AEPBrandConcierge/Sources/Extensions/MarkdownRenderer.swift
+++ b/AEPBrandConcierge/Sources/Extensions/MarkdownRenderer.swift
@@ -132,29 +132,54 @@ struct MarkdownRenderer {
         // its predecessor
         var events: [BuildEvent] = []
         var prevStack: [PresentationComponent] = []
-        var prevHadInlineStyling = false
+        var prevParagraphIdentity: Int?
 
         for run in attributed.runs {
             let runSlice = AttributedString(attributed[run.range])
             // Extract the concrete containers for the text based on the run's parse result
             let currentStack = containersFor(presentation: run.presentationIntent)
             let longestCommonIndex = commonPrefixLength(prevStack, currentStack)
-            // Determine whether this run carries inline styling (bold/italic/code/link/etc.)
-            let hasInlineStyling = runHasInlineStyling(run)
+            // Ask the parser (via PresentationIntent.IntentType.identity) whether this run belongs to
+            // the same paragraph as the previous one. Runs that share a paragraph (ex: "**bold** normal"
+            // within one paragraph) share the same identity, while sibling paragraphs receive distinct
+            // identities even when their container stacks are structurally identical.
+            let currentParagraphIdentity = innermostParagraphIdentity(presentation: run.presentationIntent)
+
+//            #if DEBUG
+//            Log.trace(label: LOG_TAG,
+//                      "run text=\(debugPreview(String(runSlice.characters))) "
+//                      + "stack=\(describe(currentStack)) "
+//                      + "paragraphIdentity=\(currentParagraphIdentity.map(String.init) ?? "nil") "
+//                      + "(prevIdentity=\(prevParagraphIdentity.map(String.init) ?? "nil")) "
+//                      + "commonPrefix=\(longestCommonIndex)")
+//            #endif
 
             // Only when container hierarchies are identical, create block breaks for certain types
             if longestCommonIndex == currentStack.count && prevStack.count == currentStack.count {
-                // Create a new paragraph boundary when the split isn't caused by inline styling.
+                // Emit a paragraph boundary whenever the parser reports that the innermost paragraph
+                // identity changed between runs. This is authoritative: it respects true paragraph
+                // breaks (\n\n) regardless of whether either side carries inline styling, and does not
+                // falsely split a single paragraph that contains multiple inline runs.
                 if prevStack.last == .paragraph
                     && currentStack.last == .paragraph
-                    && !hasInlineStyling
-                    && !prevHadInlineStyling {
+                    && prevParagraphIdentity != currentParagraphIdentity {
+//                    #if DEBUG
+//                    Log.trace(label: LOG_TAG,
+//                              "paragraph boundary detected: identity "
+//                              + "\(prevParagraphIdentity.map(String.init) ?? "nil") -> "
+//                              + "\(currentParagraphIdentity.map(String.init) ?? "nil") "
+//                              + "- emitting close(.paragraph) + open(.paragraph)")
+//                    #endif
                     events.append(.close(.paragraph))
                     events.append(.open(.paragraph))
                 }
 
                 // Create a new code block boundary
                 if prevStack.last == .codeBlock && currentStack.last == .codeBlock {
+//                    #if DEBUG
+//                    Log.trace(label: LOG_TAG,
+//                              "code block boundary detected - emitting close(.codeBlock) + open(.codeBlock)")
+//                    #endif
                     events.append(.close(.codeBlock))
                     events.append(.open(.codeBlock))
                 }
@@ -175,7 +200,8 @@ struct MarkdownRenderer {
 
             // Handle special leaf components based on innermost container
 //            #if DEBUG
-//            Log.trace(label: LOG_TAG, "consume leaf for innermost=\(String(describing: currentStack.last.map { describe($0) }))")
+//            Log.trace(label: LOG_TAG,
+//                      "consume leaf innermost=\(currentStack.last.map { describe($0) } ?? "nil")")
 //            #endif
             if case .some(.thematicBreak) = currentStack.last {
                 events.append(.divider)
@@ -188,7 +214,7 @@ struct MarkdownRenderer {
 
             // Once run processing is complete, set up properties for the next run
             prevStack = currentStack
-            prevHadInlineStyling = hasInlineStyling
+            prevParagraphIdentity = currentParagraphIdentity
         }
 
         // This closes the final run's common components
@@ -256,6 +282,26 @@ struct MarkdownRenderer {
         }
 
         return containers
+    }
+
+    /// Returns the identity of the innermost `.paragraph` component for a run's presentation intent,
+    /// or `nil` if the run is not inside a paragraph container (ex: a header, code block, or thematic
+    /// break). `PresentationIntent.IntentType.identity` is assigned by the parser per block instance,
+    /// so two sibling paragraphs receive different identity values even when their container stacks
+    /// are structurally identical — which is exactly what we need to detect true paragraph breaks.
+    ///
+    /// - Parameter presentation: The run's `PresentationIntent` (if any).
+    /// - Returns: The identity of the innermost paragraph component, or `nil`.
+    private func innermostParagraphIdentity(presentation: PresentationIntent?) -> Int? {
+        guard let presentation = presentation else { return nil }
+        // `presentation.components` is delivered innermost-first by the parser, so the first
+        // `.paragraph` encountered is the innermost text container for this run.
+        for component in presentation.components {
+            if case .paragraph = component.kind {
+                return component.identity
+            }
+        }
+        return nil
     }
 
     /// Returns the length of the shared leading sequence between two container stacks.
@@ -674,22 +720,6 @@ struct MarkdownRenderer {
         }
     }
 
-    /// Returns true if the run has any inline styling indicators:
-    /// - Bold
-    /// - Italic
-    /// - Inline code
-    /// - Link
-    /// - Underline or
-    /// - Font override
-    ///
-    /// Used to avoid splitting paragraphs due to inline styling changes.
-    private func runHasInlineStyling(_ run: AttributedString.Runs.Run) -> Bool {
-        if run.inlinePresentationIntent != nil { return true }
-        if run.attributes[AttributeScopes.FoundationAttributes.LinkAttribute.self] != nil { return true }
-        if run.attributes[AttributeScopes.UIKitAttributes.FontAttribute.self] != nil { return true }
-        if run.attributes[AttributeScopes.UIKitAttributes.UnderlineStyleAttribute.self] != nil { return true }
-        return false
-    }
 }
 
 #if DEBUG
@@ -749,6 +779,22 @@ extension MarkdownRenderer {
         case .codeBlock: return "codeBlock"
         case .thematicBreak: return "thematicBreak"
         }
+    }
+
+    /// Returns a compact `[outer > ... > inner]` string for a stack of containers, used in debug logs.
+    private func describe(_ stack: [PresentationComponent]) -> String {
+        guard !stack.isEmpty else { return "[]" }
+        return "[" + stack.map { describe($0) }.joined(separator: " > ") + "]"
+    }
+
+    /// Produces a short, newline-escaped preview of a run's text for readable log output.
+    private func debugPreview(_ text: String, limit: Int = 40) -> String {
+        let escaped = text
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+        if escaped.count <= limit { return "\"\(escaped)\"" }
+        let endIndex = escaped.index(escaped.startIndex, offsetBy: limit)
+        return "\"\(escaped[..<endIndex])…\""
     }
 }
 #endif

--- a/AEPBrandConcierge/Sources/Views/Chat/Messages/CitationAttachmentBuilder.swift
+++ b/AEPBrandConcierge/Sources/Views/Chat/Messages/CitationAttachmentBuilder.swift
@@ -87,13 +87,19 @@ enum CitationAttachmentBuilder {
         let baselineOffset = (baseFont.capHeight - badgeSize.height) / 2
         attachment.bounds = CGRect(x: 0, y: baselineOffset, width: badgeSize.width, height: badgeSize.height)
 
-        let result = NSMutableAttributedString(attachment: attachment)
+        // Build the badge as its own attributed fragment
+        let badge = NSMutableAttributedString(attachment: attachment)
         if let url = URL(string: marker.source.url) {
-            result.addAttribute(.link, value: url, range: NSRange(location: 0, length: result.length))
+            badge.addAttribute(.link, value: url, range: NSRange(location: 0, length: badge.length))
         }
 
-        // Add a space after the badge to separate it from the next character.
-        result.append(NSAttributedString(string: " "))
+        // Prepend a space so the badge sits slightly away from the preceding word, while keeping 
+        // it flush against any trailing punctuation like periods or commas. 
+        // * ex: `swift.org [1].` rather than `swift.org[1].`
+        // The space is injected here after the markdown parser has already finished 
+        // so it doesn't affect paragraph/block detection.
+        let result = NSMutableAttributedString(string: " ")
+        result.append(badge)
         return result
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

### Paragraph boundary detection (MarkdownRenderer.swift) 
Improved true paragraph detection by replacing the fragile custom "inline styling" heuristic with the parser-authoritative `PresentationIntent.IntentType.identity` of the innermost `.paragraph` component. 
* The old heuristic incorrectly split a single paragraph whenever an inline run (bold/italic/code/link) appeared, and failed to split sibling paragraphs whose container stacks were structurally identical. 
* Using per-paragraph identity fixes both cases: 
    1. Runs in the same paragraph always share an identity, and 
    2. true `\n\n` breaks always produce a new one

For the example string:
`
**1.**\n\n**Availability**\n\n- **Weekdays**: 8:00 AM - 6:00 PM\n- **Weekends**: 10:00 AM - 4:00 PM\n\n**Email**\n\n[contact@example.com](mailto:contact@example.com)\n\n**Venue**\n\nExample Pavilion – North Wing\n\n**Website**\n\n[View details](https://example.com/listings/north-wing)\n\n**Location**\n\n250 Placeholder Avenue\nRedwood City, CA 94063\n\n**Capacity**: 120 people
`

| Before | After |
|--------|-------|
| <img width="350" alt="IMG_0021" src="https://github.com/user-attachments/assets/98f9cade-d932-492f-8178-bbb2febb4c18" />       |     <img width="350" alt="IMG_0020" src="https://github.com/user-attachments/assets/4d815c14-3d98-4bee-957a-cc0beec277cb" />  |




### Citation badge spacing (CitationAttachmentBuilder.swift)
Moved the separator space from after to before the badge so the marker hugs trailing punctuation instead of detaching from it
* Note that the space is inserted into the text **after** markdown parsing so it doesn't affect parsing logic

| Before | After |
|--------|-------|
|   <img width="280" height="156" alt="Screenshot 2026-04-16 at 5 15 59 PM" src="https://github.com/user-attachments/assets/4766ae5b-7a71-4f96-9bb6-6e3a520f24c8" />    |    <img width="274" height="152" alt="Screenshot 2026-04-16 at 5 11 56 PM" src="https://github.com/user-attachments/assets/f4a33b6a-7423-4420-b53c-88c823384b21" />    |


### Markdown renderer logging
Added commented-out trace logs and two `#if DEBUG` helpers (describe(_ stack:), debugPreview(_:limit:)) to make future debugging of markdown parsing easier

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
