### PR TITLE
Input bar revamp changes 

### DIFF
--- a/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeBehavior.swift
+++ b/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeBehavior.swift
@@ -39,6 +39,10 @@ public struct ConciergeInputBehavior: Codable {
     public var silenceThreshold: Float
     /// Seconds of continuous silence after speech before auto-stopping capture.
     public var silenceDuration: TimeInterval
+    /// Whether to show the rotating glow border animation on the input bar during voice recording.
+    public var enableRecordingAnimation: Bool
+    /// Asset name for the stop recording button icon. Falls back to SF Symbol `stop.circle.fill` when empty or not found.
+    public var stopRecordingIcon: String
 
     private enum CodingKeys: String, CodingKey {
         case enableVoiceInput
@@ -47,6 +51,8 @@ public struct ConciergeInputBehavior: Codable {
         case sendButtonStyle
         case silenceThreshold
         case silenceDuration
+        case enableRecordingAnimation
+        case stopRecordingIcon
     }
 
     public init(
@@ -55,7 +61,9 @@ public struct ConciergeInputBehavior: Codable {
         showAiChatIcon: ConciergeIconConfig? = nil,
         sendButtonStyle: String = "default",
         silenceThreshold: Float = 0.02,
-        silenceDuration: TimeInterval = 2.0
+        silenceDuration: TimeInterval = 2.0,
+        enableRecordingAnimation: Bool = true,
+        stopRecordingIcon: String = ""
     ) {
         self.enableVoiceInput = enableVoiceInput
         self.disableMultiline = disableMultiline
@@ -63,6 +71,8 @@ public struct ConciergeInputBehavior: Codable {
         self.sendButtonStyle = sendButtonStyle
         self.silenceThreshold = silenceThreshold
         self.silenceDuration = silenceDuration
+        self.enableRecordingAnimation = enableRecordingAnimation
+        self.stopRecordingIcon = stopRecordingIcon
     }
 
     public init(from decoder: Decoder) throws {
@@ -77,6 +87,8 @@ public struct ConciergeInputBehavior: Codable {
         } else {
             silenceDuration = 2.0
         }
+        enableRecordingAnimation = try container.decodeIfPresent(Bool.self, forKey: .enableRecordingAnimation) ?? true
+        stopRecordingIcon = try container.decodeIfPresent(String.self, forKey: .stopRecordingIcon) ?? ""
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -87,6 +99,8 @@ public struct ConciergeInputBehavior: Codable {
         try container.encode(sendButtonStyle, forKey: .sendButtonStyle)
         try container.encode(silenceThreshold, forKey: .silenceThreshold)
         try container.encode(silenceDuration, forKey: .silenceDuration)
+        try container.encode(enableRecordingAnimation, forKey: .enableRecordingAnimation)
+        try container.encode(stopRecordingIcon, forKey: .stopRecordingIcon)
     }
 }
 

--- a/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeBehavior.swift
+++ b/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeBehavior.swift
@@ -62,7 +62,7 @@ public struct ConciergeInputBehavior: Codable {
         sendButtonStyle: String = "default",
         silenceThreshold: Float = 0.02,
         silenceDuration: TimeInterval = 2.0,
-        enableRecordingAnimation: Bool = true,
+        enableRecordingAnimation: Bool = false,
         stopRecordingIcon: String? = nil
     ) {
         self.enableVoiceInput = enableVoiceInput
@@ -87,7 +87,7 @@ public struct ConciergeInputBehavior: Codable {
         } else {
             silenceDuration = 2.0
         }
-        enableRecordingAnimation = try container.decodeIfPresent(Bool.self, forKey: .enableRecordingAnimation) ?? true
+        enableRecordingAnimation = try container.decodeIfPresent(Bool.self, forKey: .enableRecordingAnimation) ?? false
         stopRecordingIcon = try container.decodeIfPresent(String.self, forKey: .stopRecordingIcon)
     }
 

--- a/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeBehavior.swift
+++ b/AEPBrandConcierge/Sources/Theme/Models/ConciergeThemeBehavior.swift
@@ -41,8 +41,8 @@ public struct ConciergeInputBehavior: Codable {
     public var silenceDuration: TimeInterval
     /// Whether to show the rotating glow border animation on the input bar during voice recording.
     public var enableRecordingAnimation: Bool
-    /// Asset name for the stop recording button icon. Falls back to SF Symbol `stop.circle.fill` when empty or not found.
-    public var stopRecordingIcon: String
+    /// Asset name for the stop recording button icon. Falls back to SF Symbol `stop.circle.fill` when `nil`.
+    public var stopRecordingIcon: String?
 
     private enum CodingKeys: String, CodingKey {
         case enableVoiceInput
@@ -63,7 +63,7 @@ public struct ConciergeInputBehavior: Codable {
         silenceThreshold: Float = 0.02,
         silenceDuration: TimeInterval = 2.0,
         enableRecordingAnimation: Bool = true,
-        stopRecordingIcon: String = ""
+        stopRecordingIcon: String? = nil
     ) {
         self.enableVoiceInput = enableVoiceInput
         self.disableMultiline = disableMultiline
@@ -88,7 +88,7 @@ public struct ConciergeInputBehavior: Codable {
             silenceDuration = 2.0
         }
         enableRecordingAnimation = try container.decodeIfPresent(Bool.self, forKey: .enableRecordingAnimation) ?? true
-        stopRecordingIcon = try container.decodeIfPresent(String.self, forKey: .stopRecordingIcon) ?? ""
+        stopRecordingIcon = try container.decodeIfPresent(String.self, forKey: .stopRecordingIcon)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -100,7 +100,7 @@ public struct ConciergeInputBehavior: Codable {
         try container.encode(silenceThreshold, forKey: .silenceThreshold)
         try container.encode(silenceDuration, forKey: .silenceDuration)
         try container.encode(enableRecordingAnimation, forKey: .enableRecordingAnimation)
-        try container.encode(stopRecordingIcon, forKey: .stopRecordingIcon)
+        try container.encodeIfPresent(stopRecordingIcon, forKey: .stopRecordingIcon)
     }
 }
 

--- a/AEPBrandConcierge/Sources/Views/Chat/Composer/ChatComposer.swift
+++ b/AEPBrandConcierge/Sources/Views/Chat/Composer/ChatComposer.swift
@@ -78,8 +78,8 @@ struct ChatComposer: View {
                             RoundedRectangle(cornerRadius: theme.layout.inputBorderRadius)
                                 .stroke(theme.colors.input.outlineFocus.color, lineWidth: theme.layout.inputFocusOutlineWidth)
                         }
-                        // Recording glow border
-                        if case .recording = inputState {
+                        // Recording glow border (configurable via theme)
+                        if case .recording = inputState, theme.behavior.input.enableRecordingAnimation {
                             RotatingGlowBorder(color: theme.colors.primary.text.color, cornerRadius: theme.layout.inputBorderRadius)
                         }
                     }

--- a/AEPBrandConcierge/Sources/Views/Chat/Composer/ComposerEditingView.swift
+++ b/AEPBrandConcierge/Sources/Views/Chat/Composer/ComposerEditingView.swift
@@ -55,7 +55,7 @@ struct ComposerEditingView: View {
             .frame(height: max(40, measuredHeight))
             .animation(.easeInOut(duration: 0.15), value: measuredHeight)
 
-            if hasText {
+            if hasText, inputState != .recording {
                 Button(action: {
                     inputText = ""
                 }) {
@@ -70,17 +70,19 @@ struct ComposerEditingView: View {
             }
 
             if case .recording = inputState {
-                // Recording uses the send/mic slot: waveform is tappable to finish (`onStopRecording`).
-                //
-                // Future: reintroduce a dedicated stop control (e.g. icon button) beside or instead of
-                // tap-to-stop on the waveform, and gate it with theme JSON such as
-                // `behavior.input.showVoiceStopButton` (Bool, default false) on `ConciergeInputBehavior`
+                // Waveform visual indicator
+                AudioWaveformView(
+                    audioLevel: audioLevel,
+                    barColor: theme.colors.primary.primary.color
+                )
+                .frame(width: theme.layout.inputButtonWidth, height: theme.layout.inputButtonHeight)
+
+                // Dedicated stop button (icon configurable via theme)
                 Button(action: onStopRecording) {
-                    AudioWaveformView(
-                        audioLevel: audioLevel,
-                        barColor: theme.colors.primary.primary.color
-                    )
-                    .frame(width: theme.layout.inputButtonWidth, height: theme.layout.inputButtonHeight)
+                    BrandIcon(assetName: theme.behavior.input.stopRecordingIcon, systemName: "stop.circle.fill")
+                        .font(.system(size: theme.layout.inputButtonHeight, weight: .semibold))
+                        .foregroundColor(theme.colors.input.micIconColor?.color ?? theme.colors.primary.primary.color)
+                        .frame(width: theme.layout.inputButtonWidth, height: theme.layout.inputButtonHeight, alignment: .center)
                 }
                 .buttonStyle(.plain)
                 .contentShape(Rectangle())

--- a/AEPBrandConcierge/Sources/Views/Chat/Composer/ComposerEditingView.swift
+++ b/AEPBrandConcierge/Sources/Views/Chat/Composer/ComposerEditingView.swift
@@ -42,7 +42,7 @@ struct ComposerEditingView: View {
     }
 
     var body: some View {
-        HStack(alignment: .center) {
+        HStack(alignment: .bottom) {
             SelectableTextView(
                 text: $inputText,
                 selectedRange: $selectedRange,
@@ -54,7 +54,7 @@ struct ComposerEditingView: View {
                 font: resolvedInputFont,
                 textColor: UIColor(theme.components.inputBar.textColor.color),
                 placeholderTextColor: UIColor(theme.components.inputBar.placeholderColor.color),
-                maxLines: theme.behavior.input.disableMultiline ? 1 : 15,
+                maxLines: theme.behavior.input.disableMultiline ? 1 : 10,
                 onEditingChanged: onEditingChanged
             )
             .frame(height: max(40, measuredHeight))
@@ -73,6 +73,7 @@ struct ComposerEditingView: View {
                 .contentShape(Rectangle())
                 .accessibilityLabel("Clear text")
                 .transition(buttonTransition)
+                .padding(.bottom, 8)
             }
 
             if case .recording = inputState {
@@ -82,6 +83,7 @@ struct ComposerEditingView: View {
                     barColor: theme.colors.primary.primary.color
                 )
                 .frame(width: theme.layout.inputButtonWidth, height: theme.layout.inputButtonHeight)
+                .padding(.bottom, 8)
 
                 // Dedicated stop button (icon configurable via theme)
                 Button(action: onStopRecording) {
@@ -93,6 +95,7 @@ struct ComposerEditingView: View {
                 .buttonStyle(.plain)
                 .contentShape(Rectangle())
                 .accessibilityLabel("Stop recording")
+                .padding(.bottom, 8)
             } else if hasText {
                 // Send button appears in the same slot once text is present
                 if theme.behavior.input.sendButtonStyle == "arrow" {
@@ -109,6 +112,7 @@ struct ComposerEditingView: View {
                     .accessibilityLabel(theme.text.inputSendAria)
                     .disabled(!sendEnabled)
                     .transition(buttonTransition)
+                    .padding(.bottom, 8)
                 } else {
                     Button(action: onSend) {
                         BrandIcon(assetName: "S2_Icon_Send_20_N", systemName: "paperplane")
@@ -124,6 +128,7 @@ struct ComposerEditingView: View {
                     .accessibilityLabel(theme.text.inputSendAria)
                     .disabled(!sendEnabled)
                     .transition(buttonTransition)
+                    .padding(.bottom, 8)
                 }
             } else if showMic {
                 // Mic button when idle with no text
@@ -137,6 +142,7 @@ struct ComposerEditingView: View {
                 .accessibilityLabel(theme.text.inputMicAria)
                 .disabled(!micEnabled)
                 .transition(buttonTransition)
+                .padding(.bottom, 8)
             }
         }
         .animation(.easeInOut(duration: 0.2), value: inputState)

--- a/AEPBrandConcierge/Sources/Views/Chat/Composer/ComposerEditingView.swift
+++ b/AEPBrandConcierge/Sources/Views/Chat/Composer/ComposerEditingView.swift
@@ -36,6 +36,11 @@ struct ComposerEditingView: View {
         !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    /// Fade + horizontal slide transition animation.
+    private var buttonTransition: AnyTransition {
+        .opacity.combined(with: .move(edge: .trailing))
+    }
+
     var body: some View {
         HStack(alignment: .center) {
             SelectableTextView(
@@ -67,6 +72,7 @@ struct ComposerEditingView: View {
                 .buttonStyle(.plain)
                 .contentShape(Rectangle())
                 .accessibilityLabel("Clear text")
+                .transition(buttonTransition)
             }
 
             if case .recording = inputState {
@@ -79,7 +85,7 @@ struct ComposerEditingView: View {
 
                 // Dedicated stop button (icon configurable via theme)
                 Button(action: onStopRecording) {
-                    BrandIcon(assetName: theme.behavior.input.stopRecordingIcon, systemName: "stop.circle.fill")
+                    BrandIcon(assetName: theme.behavior.input.stopRecordingIcon ?? "", systemName: "stop.circle.fill")
                         .font(.system(size: theme.layout.inputButtonHeight, weight: .semibold))
                         .foregroundColor(theme.colors.input.micIconColor?.color ?? theme.colors.primary.primary.color)
                         .frame(width: theme.layout.inputButtonWidth, height: theme.layout.inputButtonHeight, alignment: .center)
@@ -102,6 +108,7 @@ struct ComposerEditingView: View {
                     .contentShape(Rectangle())
                     .accessibilityLabel(theme.text.inputSendAria)
                     .disabled(!sendEnabled)
+                    .transition(buttonTransition)
                 } else {
                     Button(action: onSend) {
                         BrandIcon(assetName: "S2_Icon_Send_20_N", systemName: "paperplane")
@@ -116,6 +123,7 @@ struct ComposerEditingView: View {
                     .contentShape(Rectangle())
                     .accessibilityLabel(theme.text.inputSendAria)
                     .disabled(!sendEnabled)
+                    .transition(buttonTransition)
                 }
             } else if showMic {
                 // Mic button when idle with no text
@@ -128,8 +136,11 @@ struct ComposerEditingView: View {
                 .contentShape(Rectangle())
                 .accessibilityLabel(theme.text.inputMicAria)
                 .disabled(!micEnabled)
+                .transition(buttonTransition)
             }
         }
+        .animation(.easeInOut(duration: 0.2), value: inputState)
+        .animation(.easeInOut(duration: 0.2), value: hasText)
     }
 }
 


### PR DESCRIPTION
## Description
Revamps the input bar recording UX by separating the waveform (now a passive visual indicator) from the stop action, introducing a dedicated stop button. Also adds two new theme-configurable fields to ConciergeInputBehavior.

Changes:

AudioWaveformView is now a visual-only indicator during recording (no longer tappable to stop)
Dedicated stop button added, with icon configurable via stopRecordingIcon in theme JSON (falls back to SF Symbol stop.circle.fill)
Rotating glow border animation during recording is disabled by default and made configurable via enableRecordingAnimation in theme JSON
Clear text button hidden during recording state
Input bar buttons use bottom alignment with padding so they stay aligned with the last line of text in multiline input
Max multiline lines reduced from 15 to 10
stopRecordingIcon changed from String to String? (nil when not provided in theme)
## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the code style of this project.