### PR TITLE
[MAR-2695] Fix voice-to-text never stopping after the user stops talking 

### DIFF
--- a/AEPBrandConcierge.xcodeproj/project.pbxproj
+++ b/AEPBrandConcierge.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		24CAB3602F2D579B00CEE013 /* SessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CAB35B2F2D579B00CEE013 /* SessionManagerTests.swift */; };
 		24CAB3612F2D579B00CEE013 /* SourceCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CAB35D2F2D579B00CEE013 /* SourceCodableTests.swift */; };
 		24CAB3622F2D579B00CEE013 /* SpeechControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CAB35E2F2D579B00CEE013 /* SpeechControllerTests.swift */; };
+		600E9EA5E91D0A6999BFA625 /* SpeechCapturerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78116DF64B3E7886464E3576 /* SpeechCapturerTests.swift */; };
 		24CAB3632F2D579B00CEE013 /* FeedbackSentimentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CAB3592F2D579B00CEE013 /* FeedbackSentimentTests.swift */; };
 		24CAB3642F2D579B00CEE013 /* SharedStateResultConciergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CAB35C2F2D579B00CEE013 /* SharedStateResultConciergeTests.swift */; };
 		24CAB3652F2D579B00CEE013 /* StringFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CAB35F2F2D579B00CEE013 /* StringFormattingTests.swift */; };
@@ -311,6 +312,7 @@
 		24CAB35C2F2D579B00CEE013 /* SharedStateResultConciergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStateResultConciergeTests.swift; sourceTree = "<group>"; };
 		24CAB35D2F2D579B00CEE013 /* SourceCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceCodableTests.swift; sourceTree = "<group>"; };
 		24CAB35E2F2D579B00CEE013 /* SpeechControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechControllerTests.swift; sourceTree = "<group>"; };
+		78116DF64B3E7886464E3576 /* SpeechCapturerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechCapturerTests.swift; sourceTree = "<group>"; };
 		24CAB35F2F2D579B00CEE013 /* StringFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringFormattingTests.swift; sourceTree = "<group>"; };
 		24CAB3702F5E000100CEE070 /* ConciergeServiceIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConciergeServiceIdentityTests.swift; sourceTree = "<group>"; };
 		24CAB38B2F3E636200CEE013 /* ConciergeLinkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConciergeLinkHandler.swift; sourceTree = "<group>"; };
@@ -722,6 +724,7 @@
 				24CAB35B2F2D579B00CEE013 /* SessionManagerTests.swift */,
 				24CAB35C2F2D579B00CEE013 /* SharedStateResultConciergeTests.swift */,
 				24CAB35D2F2D579B00CEE013 /* SourceCodableTests.swift */,
+				78116DF64B3E7886464E3576 /* SpeechCapturerTests.swift */,
 				24CAB35E2F2D579B00CEE013 /* SpeechControllerTests.swift */,
 				24CAB35F2F2D579B00CEE013 /* StringFormattingTests.swift */,
 				4CDB0DCC2EC82CA2000B85D0 /* ThemeCSSConverterTests.swift */,
@@ -1297,6 +1300,7 @@
 				24CAB3602F2D579B00CEE013 /* SessionManagerTests.swift in Sources */,
 				24CAB3612F2D579B00CEE013 /* SourceCodableTests.swift in Sources */,
 				24CAB3622F2D579B00CEE013 /* SpeechControllerTests.swift in Sources */,
+				600E9EA5E91D0A6999BFA625 /* SpeechCapturerTests.swift in Sources */,
 				24CAB3632F2D579B00CEE013 /* FeedbackSentimentTests.swift in Sources */,
 				24CAB3642F2D579B00CEE013 /* SharedStateResultConciergeTests.swift in Sources */,
 				24CAB3652F2D579B00CEE013 /* StringFormattingTests.swift in Sources */,

--- a/AEPBrandConcierge/Sources/Services/SpeechCapturer.swift
+++ b/AEPBrandConcierge/Sources/Services/SpeechCapturer.swift
@@ -26,7 +26,11 @@ class SpeechCapturer: SpeechCapturing {
     private let speechRecognizer: SFSpeechRecognizer?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
-    private let audioEngine = AVAudioEngine()
+    /// Recreated on every `prepareAudioEngineForNewInputTap()` rather than reused for the SpeechCapturer's whole
+    /// lifetime — AVAudioEngine can retain stale input-node hardware-format state across a route change (e.g.
+    /// built-in mic at 48kHz -> AirPods' Bluetooth mic profile at 24kHz), which `reset()` alone doesn't clear
+    /// and which otherwise surfaces as "formats don't match" (-10868) when starting/restarting capture.
+    private var audioEngine = AVAudioEngine()
     private var currentTranscription = ""
     private var hasInputTapInstalled = false
 
@@ -35,6 +39,27 @@ class SpeechCapturer: SpeechCapturing {
     private var silenceDuration: TimeInterval = 2.0
     private var silenceStart: Date?
     private var hasSpokeOnce = false
+
+    /// Ambient noise floor (raw RMS, uncompensated), calibrated at the start of each capture and slowly adapted
+    /// during quiet periods before speech is first detected. Used only to compute `gainCompensatedRMS`.
+    private var noiseFloor: Float?
+    private var noiseFloorCalibrationSamples: [Float] = []
+    private var captureStartTime: Date?
+
+    /// How long at the start of a capture to sample ambient noise before making speech/silence decisions.
+    private static let noiseFloorCalibrationDuration: TimeInterval = 0.3
+    /// How quickly the noise floor drifts toward newly observed quiet samples (0...1, higher = faster).
+    private static let noiseFloorAdaptationRate: Float = 0.05
+    /// Hard floor under the noise floor. Not just a divide-by-zero guard — it caps how large the compensation
+    /// gain below can get. Some mics (e.g. AirPods, calibrated as low as ~0.00005 RMS in testing) are so much
+    /// quieter than a phone's built-in mic (~0.0002-0.0006 RMS) that an uncapped gain amplifies ordinary
+    /// breathing/mouth noise after speech ends (~0.0003-0.0005 RMS observed) past `silenceThreshold`, so the
+    /// user is never detected as having gone quiet. This value is set above that observed non-speech ceiling.
+    private static let minimumNoiseFloorRMS: Float = 0.0005
+    /// What a properly auto-gain-controlled ambient floor is assumed to look like — chosen so the *default*
+    /// `silenceThreshold` (0.02) requires roughly 3x the calibrated floor to count as speech, which is what we
+    /// validated against real on-device RMS captures during the "voice to text is endless" investigation.
+    private static let targetFloorReferenceRMS: Float = 0.02 / 3.0
 
     /// Avoid overlapping pipeline restarts when route notifications fire in quick succession.
     private var isRestartingCaptureForRouteChange = false
@@ -140,8 +165,18 @@ class SpeechCapturer: SpeechCapturing {
 
     private func resetTranscriptionAndSilenceTracking() {
         currentTranscription = ""
+        resetSilenceDetectionState()
+    }
+
+    /// Resets noise-floor calibration and speech/silence tracking without touching `currentTranscription`,
+    /// so a mid-capture restart (e.g. `restartLiveCaptureAfterRouteChange`) recalibrates against the new
+    /// input device instead of reusing a floor calibrated for the previous one.
+    private func resetSilenceDetectionState() {
         silenceStart = nil
         hasSpokeOnce = false
+        noiseFloor = nil
+        noiseFloorCalibrationSamples = []
+        captureStartTime = Date()
     }
 
     private func cancelRecognitionTaskAndClearRequest() {
@@ -162,9 +197,11 @@ class SpeechCapturer: SpeechCapturing {
         if audioEngine.isRunning {
             audioEngine.stop()
         }
-        // Remove tap before `reset()` — `reset()` can clear taps; `removeTap` after that is unsafe.
+        // Remove tap on the old instance before discarding it — must happen before we drop our only reference.
         removeInputTapIfNeeded()
-        audioEngine.reset()
+        // Fresh instance so the input node re-negotiates hardware format against whatever route is active now,
+        // instead of potentially reusing a format cached from before a route change (e.g. Bluetooth mic).
+        audioEngine = AVAudioEngine()
     }
 
     private func removeInputTapIfNeeded() {
@@ -261,6 +298,7 @@ class SpeechCapturer: SpeechCapturing {
 
         cancelRecognitionTaskAndClearRequest()
         prepareAudioEngineForNewInputTap()
+        resetSilenceDetectionState()
 
         do {
             try configureAudioSessionForCapture()
@@ -309,23 +347,77 @@ class SpeechCapturer: SpeechCapturing {
         }
 
         guard let rms = rootMeanSquare else { return }
-        // Normalize to 0...1 range (clamp raw RMS, typical speech peaks ~0.1-0.3)
-        let normalized = min(rms / 0.2, 1.0)
 
+        guard let floor = calibratedNoiseFloor(for: rms) else {
+            // Still calibrating the noise floor — no speech/silence decision or meaningful level yet.
+            DispatchQueue.main.async { [weak self] in self?.audioLevelHandler?(0) }
+            return
+        }
+
+        let correctedRms = gainCompensatedRMS(rms: rms, floor: floor)
+        // Normalize to 0...1 range (clamp raw RMS, typical speech peaks ~0.1-0.3)
+        let normalized = min(correctedRms / 0.2, 1.0)
         DispatchQueue.main.async { [weak self] in self?.audioLevelHandler?(normalized) }
 
-        // Silence detection — auto-stop after `silenceDuration` of silence once speech has been detected
-        if rms > silenceThreshold {
+        detectSilence(correctedRms: correctedRms, rawRms: rms, floor: floor)
+    }
+
+    /// Establishes an ambient noise floor over the first `noiseFloorCalibrationDuration` of each capture by
+    /// averaging RMS samples, then returns that floor (and keeps it slowly adapting — see `detectSilence`).
+    /// Returns `nil` while still calibrating.
+    private func calibratedNoiseFloor(for rms: Float) -> Float? {
+        if let floor = noiseFloor {
+            return floor
+        }
+        guard let start = captureStartTime, Date().timeIntervalSince(start) >= Self.noiseFloorCalibrationDuration else {
+            noiseFloorCalibrationSamples.append(rms)
+            return nil
+        }
+        let samples = noiseFloorCalibrationSamples
+        let floor = samples.isEmpty ? rms : samples.reduce(0, +) / Float(samples.count)
+        noiseFloor = floor
+        noiseFloorCalibrationSamples = []
+        return floor
+    }
+
+    /// Software auto-gain-control: `.measurement` audio-session mode (see `configureAudioSessionForCapture`)
+    /// disables the session's own AGC, so raw mic RMS on real devices can be far quieter than the AGC'd levels
+    /// `silenceThreshold` and the waveform's `/0.2` normalization assume — see the "voice to text is endless"
+    /// investigation. Rescaling by the calibrated floor's ratio to `targetFloorReferenceRMS` restores those
+    /// original absolute-RMS assumptions without changing `silenceThreshold`'s public meaning or default.
+    private func gainCompensatedRMS(rms: Float, floor: Float) -> Float {
+        let gain = Self.targetFloorReferenceRMS / max(floor, Self.minimumNoiseFloorRMS)
+        return rms * gain
+    }
+
+    /// Silence detection against the gain-compensated RMS. A sample counts as speech once it exceeds
+    /// `silenceThreshold`; the underlying noise floor keeps drifting slowly before speech is first detected so
+    /// it tracks a slowly-changing environment (e.g. HVAC turning on) before the user starts talking.
+    private func detectSilence(correctedRms: Float, rawRms: Float, floor: Float) {
+        let now = Date()
+
+        if correctedRms > silenceThreshold {
             hasSpokeOnce = true
             silenceStart = nil
-        } else if hasSpokeOnce {
-            if silenceStart == nil {
-                silenceStart = Date()
-            } else if let start = silenceStart, Date().timeIntervalSince(start) >= silenceDuration {
-                silenceStart = nil
-                hasSpokeOnce = false
-                DispatchQueue.main.async { [weak self] in self?.silenceHandler?() }
-            }
+            return
+        }
+
+        // Only let the floor drift before speech has ever been detected this session — it tracks slow ambient
+        // change (e.g. background noise before the user starts talking), not moment-to-moment dips between
+        // words/breaths in ongoing speech. Adapting during active speech would otherwise walk the threshold up
+        // until it swallows the user's own voice, cutting them off mid-sentence.
+        if !hasSpokeOnce {
+            noiseFloor = floor * (1 - Self.noiseFloorAdaptationRate) + rawRms * Self.noiseFloorAdaptationRate
+        }
+
+        guard hasSpokeOnce else { return }
+        if silenceStart == nil {
+            silenceStart = now
+        } else if let start = silenceStart, now.timeIntervalSince(start) >= silenceDuration {
+            silenceStart = nil
+            hasSpokeOnce = false
+            Log.debug(label: LOG_TAG, "Silence threshold reached (correctedRms=\(correctedRms), threshold=\(silenceThreshold), duration=\(silenceDuration)). Firing silenceHandler.")
+            DispatchQueue.main.async { [weak self] in self?.silenceHandler?() }
         }
     }
 

--- a/AEPBrandConcierge/Sources/Services/SpeechCapturer.swift
+++ b/AEPBrandConcierge/Sources/Services/SpeechCapturer.swift
@@ -34,32 +34,50 @@ class SpeechCapturer: SpeechCapturing {
     private var currentTranscription = ""
     private var hasInputTapInstalled = false
 
+    /// Guards all "Silence detection" and "Ambient noise floor" state below: it's written from the main thread
+    /// (`configureSilenceDetection`, `resetSilenceDetectionState` via `beginCapture`/route-change restart) and
+    /// read/written from Core Audio's realtime tap-callback thread (`processAudioLevel` and everything it calls).
+    /// `AVAudioEngine.stop()`/`removeTap` don't document a guarantee that an in-flight tap callback has returned
+    /// before they do, so this can't safely rely on call ordering alone — particularly `noiseFloorCalibrationSamples`,
+    /// where a concurrent append/reassign on an `Array` from two threads is undefined behavior, not just a stale read.
+    private let silenceDetectionLock = NSLock()
+
     /// Silence detection
     private var silenceThreshold: Float = 0.02
     private var silenceDuration: TimeInterval = 2.0
-    private var silenceStart: Date?
-    private var hasSpokeOnce = false
+    /// Internal rather than private: unit-tested directly in `SpeechCapturerTests` by setting a past `Date` to
+    /// deterministically simulate elapsed silence duration without a real sleep.
+    var silenceStart: Date?
+    /// Internal rather than private: unit-tested directly in `SpeechCapturerTests`.
+    var hasSpokeOnce = false
 
     /// Ambient noise floor (raw RMS, uncompensated), calibrated at the start of each capture and slowly adapted
     /// during quiet periods before speech is first detected. Used only to compute `gainCompensatedRMS`.
-    private var noiseFloor: Float?
+    /// Internal rather than private: unit-tested directly in `SpeechCapturerTests`.
+    var noiseFloor: Float?
     private var noiseFloorCalibrationSamples: [Float] = []
-    private var captureStartTime: Date?
+    /// Internal rather than private: unit-tested directly in `SpeechCapturerTests` by setting a past `Date` to
+    /// deterministically simulate an elapsed calibration window without a real sleep.
+    var captureStartTime: Date?
 
     /// How long at the start of a capture to sample ambient noise before making speech/silence decisions.
-    private static let noiseFloorCalibrationDuration: TimeInterval = 0.3
+    static let noiseFloorCalibrationDuration: TimeInterval = 0.3
     /// How quickly the noise floor drifts toward newly observed quiet samples (0...1, higher = faster).
-    private static let noiseFloorAdaptationRate: Float = 0.05
+    static let noiseFloorAdaptationRate: Float = 0.05
     /// Hard floor under the noise floor. Not just a divide-by-zero guard — it caps how large the compensation
     /// gain below can get. Some mics (e.g. AirPods, calibrated as low as ~0.00005 RMS in testing) are so much
     /// quieter than a phone's built-in mic (~0.0002-0.0006 RMS) that an uncapped gain amplifies ordinary
     /// breathing/mouth noise after speech ends (~0.0003-0.0005 RMS observed) past `silenceThreshold`, so the
     /// user is never detected as having gone quiet. This value is set above that observed non-speech ceiling.
-    private static let minimumNoiseFloorRMS: Float = 0.0005
-    /// What a properly auto-gain-controlled ambient floor is assumed to look like — chosen so the *default*
-    /// `silenceThreshold` (0.02) requires roughly 3x the calibrated floor to count as speech, which is what we
-    /// validated against real on-device RMS captures during the "voice to text is endless" investigation.
-    private static let targetFloorReferenceRMS: Float = 0.02 / 3.0
+    static let minimumNoiseFloorRMS: Float = 0.0005
+    /// What a properly auto-gain-controlled ambient floor is assumed to look like — fixed to the *default*
+    /// `silenceThreshold` (0.02) rather than derived from the live, configurable `silenceThreshold`. Deriving it
+    /// from the live value would cancel out in `gainCompensatedRMS`'s comparison against that same value, making
+    /// `silenceThreshold` have no effect on sensitivity; keeping this fixed is what makes the live threshold scale
+    /// the required floor-multiple correctly (higher threshold -> proportionally more floor required -> less
+    /// sensitive, per its documented meaning). 3x is what we validated on real device RMS at the default value
+    /// during the "voice to text is endless" investigation — thresholds far from 0.02 are not on-device validated.
+    static let targetFloorReferenceRMS: Float = 0.02 / 3.0
 
     /// Avoid overlapping pipeline restarts when route notifications fire in quick succession.
     private var isRestartingCaptureForRouteChange = false
@@ -89,6 +107,8 @@ class SpeechCapturer: SpeechCapturing {
     func configureSilenceDetection(threshold: Float, duration: TimeInterval) {
         let resolvedThreshold = threshold > 0 ? threshold : 0.02
         let resolvedDuration = duration > 0 ? duration : 2.0
+        silenceDetectionLock.lock()
+        defer { silenceDetectionLock.unlock() }
         silenceThreshold = resolvedThreshold
         silenceDuration = resolvedDuration
     }
@@ -171,7 +191,10 @@ class SpeechCapturer: SpeechCapturing {
     /// Resets noise-floor calibration and speech/silence tracking without touching `currentTranscription`,
     /// so a mid-capture restart (e.g. `restartLiveCaptureAfterRouteChange`) recalibrates against the new
     /// input device instead of reusing a floor calibrated for the previous one.
-    private func resetSilenceDetectionState() {
+    /// Internal rather than private: unit-tested directly in `SpeechCapturerTests`.
+    func resetSilenceDetectionState() {
+        silenceDetectionLock.lock()
+        defer { silenceDetectionLock.unlock() }
         silenceStart = nil
         hasSpokeOnce = false
         noiseFloor = nil
@@ -348,6 +371,12 @@ class SpeechCapturer: SpeechCapturing {
 
         guard let rms = rootMeanSquare else { return }
 
+        // Locked for the whole section below: `calibratedNoiseFloor`/`detectSilence` read and write the same
+        // noise-floor/silence-tracking state that `configureSilenceDetection`/`resetSilenceDetectionState` write
+        // from the main thread — see `silenceDetectionLock`'s declaration.
+        silenceDetectionLock.lock()
+        defer { silenceDetectionLock.unlock() }
+
         guard let floor = calibratedNoiseFloor(for: rms) else {
             // Still calibrating the noise floor — no speech/silence decision or meaningful level yet.
             DispatchQueue.main.async { [weak self] in self?.audioLevelHandler?(0) }
@@ -365,7 +394,8 @@ class SpeechCapturer: SpeechCapturing {
     /// Establishes an ambient noise floor over the first `noiseFloorCalibrationDuration` of each capture by
     /// averaging RMS samples, then returns that floor (and keeps it slowly adapting — see `detectSilence`).
     /// Returns `nil` while still calibrating.
-    private func calibratedNoiseFloor(for rms: Float) -> Float? {
+    /// Internal rather than private: unit-tested directly in `SpeechCapturerTests`.
+    func calibratedNoiseFloor(for rms: Float) -> Float? {
         if let floor = noiseFloor {
             return floor
         }
@@ -385,7 +415,8 @@ class SpeechCapturer: SpeechCapturing {
     /// `silenceThreshold` and the waveform's `/0.2` normalization assume — see the "voice to text is endless"
     /// investigation. Rescaling by the calibrated floor's ratio to `targetFloorReferenceRMS` restores those
     /// original absolute-RMS assumptions without changing `silenceThreshold`'s public meaning or default.
-    private func gainCompensatedRMS(rms: Float, floor: Float) -> Float {
+    /// Internal rather than private: unit-tested directly in `SpeechCapturerTests`.
+    func gainCompensatedRMS(rms: Float, floor: Float) -> Float {
         let gain = Self.targetFloorReferenceRMS / max(floor, Self.minimumNoiseFloorRMS)
         return rms * gain
     }
@@ -393,7 +424,8 @@ class SpeechCapturer: SpeechCapturing {
     /// Silence detection against the gain-compensated RMS. A sample counts as speech once it exceeds
     /// `silenceThreshold`; the underlying noise floor keeps drifting slowly before speech is first detected so
     /// it tracks a slowly-changing environment (e.g. HVAC turning on) before the user starts talking.
-    private func detectSilence(correctedRms: Float, rawRms: Float, floor: Float) {
+    /// Internal rather than private: unit-tested directly in `SpeechCapturerTests`.
+    func detectSilence(correctedRms: Float, rawRms: Float, floor: Float) {
         let now = Date()
 
         if correctedRms > silenceThreshold {

--- a/AEPBrandConcierge/Tests/UnitTests/SpeechCapturerTests.swift
+++ b/AEPBrandConcierge/Tests/UnitTests/SpeechCapturerTests.swift
@@ -1,0 +1,154 @@
+/*
+ Copyright 2026 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import XCTest
+@testable import AEPBrandConcierge
+
+/// Covers the pure noise-floor/gain-compensation math in `SpeechCapturer` — the part of the "voice to text is
+/// endless" fix that doesn't require real `AVAudioEngine`/`AVAudioSession` hardware to verify. Route-change and
+/// audio-session behavior are intentionally not covered here; those were verified on-device.
+final class SpeechCapturerTests: XCTestCase {
+
+    // MARK: - gainCompensatedRMS
+
+    func test_gainCompensatedRMS_rmsEqualsFloor_mapsToTargetReference() {
+        let capturer = SpeechCapturer()
+        let floor: Float = 0.001 // above minimumNoiseFloorRMS, so the clamp doesn't engage
+
+        let corrected = capturer.gainCompensatedRMS(rms: floor, floor: floor)
+
+        XCTAssertEqual(corrected, SpeechCapturer.targetFloorReferenceRMS, accuracy: 0.000001)
+    }
+
+    func test_gainCompensatedRMS_atValidatedThreeTimesFloor_equalsDefaultThreshold() {
+        let capturer = SpeechCapturer()
+        let floor: Float = 0.001
+
+        let corrected = capturer.gainCompensatedRMS(rms: floor * 3.0, floor: floor)
+
+        XCTAssertEqual(corrected, 0.02, accuracy: 0.0001)
+    }
+
+    /// Regression test for the AirPods bug: an unusually quiet calibration (~0.00005 RMS, far below
+    /// minimumNoiseFloorRMS) must not produce a gain large enough to misread post-speech breathing/mouth noise
+    /// (~0.0005 RMS observed) as continued speech.
+    func test_gainCompensatedRMS_extremelyLowFloor_rejectsPostSpeechBreathNoise() {
+        let capturer = SpeechCapturer()
+        let airPodsStyleFloor: Float = 0.00005
+        let observedBreathNoiseRMS: Float = 0.0005
+
+        let corrected = capturer.gainCompensatedRMS(rms: observedBreathNoiseRMS, floor: airPodsStyleFloor)
+
+        XCTAssertLessThan(corrected, 0.02)
+    }
+
+    // MARK: - detectSilence
+
+    /// Regression test for the mid-sentence cutoff bug: once speech has been detected, brief quiet gaps
+    /// (pauses between words/breaths) must not drift the noise floor upward.
+    func test_detectSilence_afterSpeechDetected_doesNotAdaptFloorOnQuietGap() {
+        let capturer = SpeechCapturer()
+        let floor: Float = 0.001
+        capturer.noiseFloor = floor
+
+        let loudRms = floor * 5
+        capturer.detectSilence(correctedRms: capturer.gainCompensatedRMS(rms: loudRms, floor: floor), rawRms: loudRms, floor: floor)
+        XCTAssertTrue(capturer.hasSpokeOnce)
+
+        let quietRms = floor * 0.5
+        capturer.detectSilence(correctedRms: capturer.gainCompensatedRMS(rms: quietRms, floor: floor), rawRms: quietRms, floor: floor)
+
+        XCTAssertEqual(capturer.noiseFloor, floor)
+    }
+
+    func test_detectSilence_beforeSpeechDetected_adaptsFloorOnQuietSample() {
+        let capturer = SpeechCapturer()
+        let initialFloor: Float = 0.001
+        capturer.noiseFloor = initialFloor
+
+        let quietRms: Float = 0.0005
+        capturer.detectSilence(correctedRms: capturer.gainCompensatedRMS(rms: quietRms, floor: initialFloor), rawRms: quietRms, floor: initialFloor)
+
+        XCTAssertFalse(capturer.hasSpokeOnce)
+        XCTAssertNotEqual(capturer.noiseFloor, initialFloor)
+    }
+
+    func test_detectSilence_afterSilenceDurationElapsed_firesSilenceHandlerAndResetsHasSpokeOnce() {
+        let capturer = SpeechCapturer()
+        let floor: Float = 0.001
+        capturer.noiseFloor = floor
+        capturer.hasSpokeOnce = true
+        capturer.silenceStart = Date().addingTimeInterval(-10) // well past the default 2.0s duration
+
+        let handlerFired = expectation(description: "silenceHandler fires")
+        capturer.silenceHandler = { handlerFired.fulfill() }
+
+        let quietRms: Float = 0.0002
+        capturer.detectSilence(correctedRms: capturer.gainCompensatedRMS(rms: quietRms, floor: floor), rawRms: quietRms, floor: floor)
+
+        wait(for: [handlerFired], timeout: 1.0)
+        XCTAssertFalse(capturer.hasSpokeOnce)
+    }
+
+    func test_detectSilence_quietBeforeSilenceDurationElapsed_doesNotFireSilenceHandler() {
+        let capturer = SpeechCapturer()
+        let floor: Float = 0.001
+        capturer.noiseFloor = floor
+        capturer.hasSpokeOnce = true
+        capturer.silenceStart = Date() // just started, nowhere near the 2.0s default duration
+
+        var handlerFired = false
+        capturer.silenceHandler = { handlerFired = true }
+
+        let quietRms: Float = 0.0002
+        capturer.detectSilence(correctedRms: capturer.gainCompensatedRMS(rms: quietRms, floor: floor), rawRms: quietRms, floor: floor)
+
+        XCTAssertFalse(handlerFired)
+        XCTAssertTrue(capturer.hasSpokeOnce)
+    }
+
+    // MARK: - calibratedNoiseFloor
+
+    func test_calibratedNoiseFloor_duringCalibrationWindow_returnsNil() {
+        let capturer = SpeechCapturer()
+        capturer.resetSilenceDetectionState()
+
+        let result = capturer.calibratedNoiseFloor(for: 0.0003)
+
+        XCTAssertNil(result)
+    }
+
+    func test_calibratedNoiseFloor_afterWindowElapses_averagesAccumulatedSamples() throws {
+        let capturer = SpeechCapturer()
+        capturer.resetSilenceDetectionState()
+
+        XCTAssertNil(capturer.calibratedNoiseFloor(for: 0.0002))
+        XCTAssertNil(capturer.calibratedNoiseFloor(for: 0.0004))
+
+        // Simulate the calibration window having elapsed without a real sleep.
+        capturer.captureStartTime = Date().addingTimeInterval(-1)
+        let floor = try XCTUnwrap(capturer.calibratedNoiseFloor(for: 0.0006))
+
+        XCTAssertEqual(floor, 0.0003, accuracy: 0.00001)
+    }
+
+    func test_calibratedNoiseFloor_onceCalibrated_ignoresFurtherSamples() {
+        let capturer = SpeechCapturer()
+        capturer.resetSilenceDetectionState()
+        capturer.captureStartTime = Date().addingTimeInterval(-1)
+        let floor = capturer.calibratedNoiseFloor(for: 0.0005)
+
+        let secondCall = capturer.calibratedNoiseFloor(for: 0.9)
+
+        XCTAssertEqual(secondCall, floor)
+    }
+}


### PR DESCRIPTION

The Voice-to-Text feature's silence auto-stop was designed correctly but relied on comparing raw microphone RMS to a fixed absolute threshold — that threshold was tuned assuming AGC'd audio, but AVAudioSession's .measurement mode (used for speech recognition) disables AGC, so real device RMS was far too quiet to ever cross it. It only appeared to work in the Simulator, which doesn't reproduce this. Fixed entirely inside SpeechCapturer.swift, with no changes to the public API.

## Description

- AGC compensation: rescale raw mic RMS against a calibrated ambient noise floor before comparing to silenceThreshold, restoring the absolute-RMS assumptions the existing threshold/waveform normalization were built around.
- Mid-speech-cutoff fix: only let the noise floor adapt before speech is first detected each session, so natural pauses between words/breaths during an ongoing sentence no longer get misread as silence and stop the recording early.
- AirPods fix: raised the noise-floor safety clamp so an unusually quiet calibration (observed with AirPods, whose mic floor is far quieter than a phone's built-in mic) can't produce a gain large enough to mistake post-speech breathing/mouth noise for continued speech.
- Route-change/crash fix: recreate the AVAudioEngine instance on every new capture or audio-route change instead of reusing one for the SDK's lifetime — fixes a hardware-format-mismatch crash (-10868) when switching mic routes (e.g. connecting AirPods mid-recording) and ensures the noise floor recalibrates for the new input device.
- 
## Related Issue

Internal ticket to DSG

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
